### PR TITLE
feat: 하이라이팅될 타겟 요소를 찾는 로직 구현

### DIFF
--- a/src/getLeafTargetElements.js
+++ b/src/getLeafTargetElements.js
@@ -1,4 +1,11 @@
 function getLeafTargetElements(rootElement, targetString) {
+  if (!(rootElement instanceof Element)) {
+    throw TypeError("rootElement에는 Element를 제공해주세요.");
+  }
+  if (typeof targetString !== "string") {
+    throw TypeError("targetString에는 string을 제공해주세요.");
+  }
+
   const result = [];
 
   const textNodeIterator = document.createNodeIterator(

--- a/src/getLeafTargetElements.js
+++ b/src/getLeafTargetElements.js
@@ -1,0 +1,30 @@
+function getLeafTargetElements(rootElement, targetString) {
+  const result = [];
+
+  const textNodeIterator = document.createNodeIterator(
+    rootElement,
+    NodeFilter.SHOW_TEXT,
+    (node) => {
+      const isWanted =
+        node.textContent.includes(targetString) &&
+        node.nodeName.toLowerCase() !== "script";
+
+      return isWanted ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    }
+  );
+
+  for (
+    let currentNode = textNodeIterator.nextNode();
+    currentNode;
+    currentNode = textNodeIterator.nextNode()
+  ) {
+    const targetElement = currentNode.parentElement;
+    if (targetElement.nodeName.toLowerCase() !== "script") {
+      result.push(targetElement);
+    }
+  }
+
+  return result;
+}
+
+export default getLeafTargetElements;

--- a/src/getLeafTargetElements.js
+++ b/src/getLeafTargetElements.js
@@ -6,7 +6,7 @@ function getLeafTargetElements(rootElement, targetString) {
     throw TypeError("targetString에는 string을 제공해주세요.");
   }
 
-  const result = [];
+  const targetElements = [];
 
   const textNodeIterator = document.createNodeIterator(
     rootElement,
@@ -27,11 +27,11 @@ function getLeafTargetElements(rootElement, targetString) {
   ) {
     const targetElement = currentNode.parentElement;
     if (targetElement.nodeName.toLowerCase() !== "script") {
-      result.push(targetElement);
+      targetElements.push(targetElement);
     }
   }
 
-  return result;
+  return targetElements;
 }
 
 export default getLeafTargetElements;


### PR DESCRIPTION
### 구현사진
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/bd193889-7fa4-4c3c-82e0-ce84f67f97a8" />

### 작업 내용
- DOM을 순회하며 해당 text가 들어있는 가장 리프 요소를 반환합니다.
- 루트로 삼을 Element와 찾을 문자열을 인수로 제공해야 합니다.
- 해당 함수를 여러 장소에서 호출 할 예정이므로 올바른 인수 제공을 위해 에러를 발생시킬 수 있습니다.

### 기존 계획과 달라진 부분(+이유와 함께)
- 키워드를 단어 단위로 제공해야 합니다. 입력받은 문자열이, DOM 상에서 더 쪼개져서 위치해 있을 경우 해당 사항은 인지하지 못합니다. 드문 사례이기에 MVP 진행을 위해 추후 다루기로 했습니다.
- iframe 내부의 body는 cors-origin 이슈로인해 대응하지 않습니다. 비슷한 타서비스도 대응하지 않고 있습니다. 

### 차후 보완이 필요한 부분
- 입력 받은 문자열 사이에 테그가 끼워져 있을 경우 추후 보완 필요

### 구현한 내용(체크박스로 나타내기)
 - [ ] 입력받은 문자열을 전체 포함하고 있는 가장 자손인 요소 반환
 - [x]  재사용이 가능하여야 함
 - [x] body 요소를 대상으로 작동하여야 함

### 리뷰어가 집중적으로 바줬으면 하는 것

### 관련 이슈
Closes #7 
Closes #6 
