### PR TITLE
feat: 검색쿼리 키워드 취득 로직 구현

### DIFF
--- a/src/getSearchKeywords.js
+++ b/src/getSearchKeywords.js
@@ -1,9 +1,7 @@
 function getSearchKeywords() {
   const currentUrl = new URL(window.location.href);
   const urlParams = new URLSearchParams(currentUrl.search);
-  const allCondition = ["+", "AND", "|", "OR", "*", "-", ",", `"`, "(", ")"];
-  const filterCondition = ["+", "AND", "|", "OR", "*", " ", ","];
-  const exceptionCondition = [`"`, "(", ")"];
+  const allCondition = ["+", " AND ", "|", " OR ", " -", `"`, " ", ","];
   let keywords;
 
   for (const key of urlParams.keys()) {
@@ -12,34 +10,44 @@ function getSearchKeywords() {
     }
   }
 
+  if (keywords.includes(`"`)) {
+    keywords = keywords.replaceAll(`"`, "");
+    return [keywords];
+  }
+
   for (let i = 0; i < allCondition.length; i++) {
     if (keywords === allCondition[i]) {
-      return keywords;
+      return [keywords];
     }
   }
 
-  exceptionCondition.forEach((condition) => {
-    if (keywords.includes(condition)) {
-      keywords = keywords.replaceAll(`"`, "");
-      keywords = keywords.replaceAll("(", "");
-      keywords = keywords.replaceAll(")", "");
+  for (let i = 0; i < allCondition.length; i++) {
+    if (
+      keywords[0] === allCondition[i] ||
+      keywords[keywords.length - 1] === allCondition[i]
+    ) {
+      return [keywords];
     }
-  });
-
-  if (keywords.includes("-")) {
-    const deleteIndex = keywords.indexOf("-");
-    keywords = keywords.slice(0, deleteIndex - 1);
   }
 
-  filterCondition.forEach((condition) => {
+  if (keywords.includes(" -")) {
+    const deleteIndex = keywords.indexOf(" -");
+    keywords = keywords.slice(0, deleteIndex);
+  }
+
+  allCondition.forEach((condition) => {
     if (keywords.includes(condition)) {
       keywords = keywords.split(condition);
     }
   });
 
-  return keywords;
+  if (typeof keywords === "object") {
+    keywords = keywords.filter((keyword) => keyword !== "");
+    keywords = keywords.map((keyword) => keyword.trim());
+    return keywords;
+  } else {
+    return [keywords];
+  }
 }
 
 getSearchKeywords();
-
-// window.onload

--- a/src/getSearchKeywords.js
+++ b/src/getSearchKeywords.js
@@ -1,8 +1,8 @@
-function getSearchKeywords() {
+export function getSearchKeywords() {
   const currentUrl = new URL(window.location.href);
   const urlParams = new URLSearchParams(currentUrl.search);
   const allCondition = ["+", " AND ", "|", " OR ", " -", `"`, " ", ","];
-  let keywords;
+  let keywords = null;
 
   for (const key of urlParams.keys()) {
     if (key === "q" || key === "query") {
@@ -41,7 +41,7 @@ function getSearchKeywords() {
     }
   });
 
-  if (typeof keywords === "object") {
+  if (Array.isArray(keywords)) {
     keywords = keywords.filter((keyword) => keyword !== "");
     keywords = keywords.map((keyword) => keyword.trim());
     return keywords;
@@ -49,5 +49,3 @@ function getSearchKeywords() {
     return [keywords];
   }
 }
-
-getSearchKeywords();

--- a/src/getSearchKeywords.js
+++ b/src/getSearchKeywords.js
@@ -1,0 +1,45 @@
+function getSearchKeywords() {
+  const currentUrl = new URL(window.location.href);
+  const urlParams = new URLSearchParams(currentUrl.search);
+  const allCondition = ["+", "AND", "|", "OR", "*", "-", ",", `"`, "(", ")"];
+  const filterCondition = ["+", "AND", "|", "OR", "*", " ", ","];
+  const exceptionCondition = [`"`, "(", ")"];
+  let keywords;
+
+  for (const key of urlParams.keys()) {
+    if (key === "q" || key === "query") {
+      keywords = urlParams.get(key);
+    }
+  }
+
+  for (let i = 0; i < allCondition.length; i++) {
+    if (keywords === allCondition[i]) {
+      return keywords;
+    }
+  }
+
+  exceptionCondition.forEach((condition) => {
+    if (keywords.includes(condition)) {
+      keywords = keywords.replaceAll(`"`, "");
+      keywords = keywords.replaceAll("(", "");
+      keywords = keywords.replaceAll(")", "");
+    }
+  });
+
+  if (keywords.includes("-")) {
+    const deleteIndex = keywords.indexOf("-");
+    keywords = keywords.slice(0, deleteIndex - 1);
+  }
+
+  filterCondition.forEach((condition) => {
+    if (keywords.includes(condition)) {
+      keywords = keywords.split(condition);
+    }
+  });
+
+  return keywords;
+}
+
+getSearchKeywords();
+
+// window.onload


### PR DESCRIPTION
### 작업 내용
사용자가 포털사이트에서 특정 단어 또는 문장을 검색할 시, 검색쿼리 값을 취득하는 로직 구현
### 기존 계획과 달라진 부분(+이유와 함께)
- [ ] 오타 및 한글을 그대로 영타로 적는 경우
-> 기존에 존재하던 특정 단어 검색 기능도 이런 예외사례를 대응하지 않았고, 사용자의 오타까지 대응할 필요가 없다고 판단함
### 차후 보완이 필요한 부분
검색 명령어를 혼합하여 사용할 시 이에 대한 논의가 필요함
### 구현한 내용(체크박스로 나타내기)
- [X] keyword, “keyword” 등과 같은 조건적 검색에 대응
- [X] keyword1 keyword2 keyword3와 같은 여러 단어 나열
- [ ] 오타 및 한글을 그대로 영타로 적는 경우
- [X] 문장으로 검색하는 경우
-> 문장으로 적는 경우 본 프로젝트의 검색 명령어 기준인 공백을 기준으로 나누어 추출
### 리뷰어가 집중적으로 바줬으면 하는 것
검색 관련하여 예외케이스들이 많이 존재하다보니, 미처 파악하지 못한 케이스들이 있을 수 있습니다.
발견하시면 말씀주시기 바랍니다.
### 관련 이슈
feat: 검색쿼리 키워드 취득 로직 구현 #5 
