### PR TITLE
feat: description 데이터 추출 로직 구현

### DIFF
--- a/src/getDescription.js
+++ b/src/getDescription.js
@@ -1,0 +1,31 @@
+export function getDescription() {
+  const metaDescription = document.querySelector(`meta[name="description"]`);
+  const metaOgDescription = document.querySelector(
+    `meta[property="og:description"]`
+  );
+
+  let metaDescriptionText = metaDescription
+    .getAttribute("content")
+    .replaceAll(/png|jpg|jpeg|gif/gi, " ");
+  let metaOgDescriptionText = metaOgDescription
+    .getAttribute("content")
+    .replaceAll(/png|jpg|jpeg|gif/gi, " ");
+
+  const metaFilterText = metaDescriptionText
+    .split(/[|!?|~,'"|/./]/)
+    .filter((text) => text !== "")
+    .map((blank) => blank.trim());
+  const metaOgFilterText = metaOgDescriptionText
+    .split(/[|!?|~,'"|/./]/)
+    .filter((text) => text !== "")
+    .map((blank) => blank.trim());
+
+  const finalFilterDescription = [];
+
+  metaDescription && finalFilterDescription.push(metaFilterText);
+  metaOgDescription && finalFilterDescription.push(metaOgFilterText);
+
+  if (metaDescription && metaOgDescription === false) {
+    throw Error("찾으시는 정보가 없습니다.");
+  }
+}

--- a/src/getDescription.js
+++ b/src/getDescription.js
@@ -1,13 +1,15 @@
 export function getDescription() {
-  const metaDescription = document.querySelector(`meta[name="description"]`);
-  const metaOgDescription = document.querySelector(
+  const descriptionMetaElement = document.querySelector(
+    `meta[name="description"]`
+  );
+  const ogDescriptionMetaElement = document.querySelector(
     `meta[property="og:description"]`
   );
 
-  let metaDescriptionText = metaDescription
+  let metaDescriptionText = descriptionMetaElement
     .getAttribute("content")
     .replaceAll(/png|jpg|jpeg|gif/gi, " ");
-  let metaOgDescriptionText = metaOgDescription
+  let metaOgDescriptionText = ogDescriptionMetaElement
     .getAttribute("content")
     .replaceAll(/png|jpg|jpeg|gif/gi, " ");
 
@@ -22,10 +24,10 @@ export function getDescription() {
 
   const finalFilterDescription = [];
 
-  metaDescription && finalFilterDescription.push(metaFilterText);
-  metaOgDescription && finalFilterDescription.push(metaOgFilterText);
+  descriptionMetaElement && finalFilterDescription.push(metaFilterText);
+  ogDescriptionMetaElement && finalFilterDescription.push(metaOgFilterText);
 
-  if (metaDescription && metaOgDescription === false) {
+  if (descriptionMetaElement && ogDescriptionMetaElement === false) {
     throw Error("찾으시는 정보가 없습니다.");
   }
 }

--- a/src/getDescription.js
+++ b/src/getDescription.js
@@ -27,7 +27,7 @@ export function getDescription() {
   descriptionMetaElement && finalFilterDescription.push(metaFilterText);
   ogDescriptionMetaElement && finalFilterDescription.push(metaOgFilterText);
 
-  if (descriptionMetaElement && ogDescriptionMetaElement === false) {
+  if (!descriptionMetaElement && !ogDescriptionMetaElement) {
     throw Error("찾으시는 정보가 없습니다.");
   }
 }


### PR DESCRIPTION
### 작업 내용
사용자의 검색어 기반으로 반환된 설명글을 문장단위로 나누고 불필요한 텍스트는 제거 후 반환하는 로직 구현 

### 차후 보완이 필요한 부분
중복 코드가 많은 점이 있어 코드 리팩토링이 필요함

### 구현한 내용(체크박스로 나타내기)
- [x]  검색결과에서 description을 추출하는 로직 구현
- [x]  description을 가공하여, 가장 일치도가 높은 keywords 생성하는 기능

### 리뷰어가 집중적으로 바줬으면 하는 것
재사용성 가능하게끔 변수명을 지정할려다보니 네이밍이 길어진 점이 있습니다. 
변경하면 가독성이 더 좋을만한 변수명이 있다면 편히 의견 부탁드리겠습니다!

### 관련 이슈
feat: description 데이터 추출 로직 구현 #4 
