### PR TITLE
feat: 로그인 기능

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -4,3 +4,7 @@
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
+
+chrome.identity.getAuthToken({ interactive: true }, function (token) {
+  return token;
+});

--- a/background/background.js
+++ b/background/background.js
@@ -5,6 +5,11 @@ chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
 
-chrome.identity.getAuthToken({ interactive: true }, function (token) {
-  return token;
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.message === "userStatus") {
+    chrome.identity.getAuthToken({ interactive: true }, function (token) {
+      sendResponse({ message: token });
+    });
+  }
+  return true;
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
         "warn",
         { allowConstantExport: true },
       ],
+      "react/prop-types": "off",
     },
   },
   eslintConfigPrettier,

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,14 @@
       "js": ["assets/content.js"]
     }
   ],
-  "permissions": ["sidePanel", "activeTab", "scripting"],
+  "oauth2": {
+    "client_id": "399990500021-ph0q3br6s9io670u9vt0sotshsk5fafq.apps.googleusercontent.com",
+    "scopes": [
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/userinfo.email"
+    ]
+  },
+  "permissions": ["sidePanel", "activeTab", "scripting", "identity", "tabs"],
   "host_permissions": ["<all_urls>"],
   "commands": {
     "_execute_action": {

--- a/src/components/shared/IconButton.jsx
+++ b/src/components/shared/IconButton.jsx
@@ -1,9 +1,27 @@
-/* eslint-disable react/prop-types */
+/*global chrome*/
+import { useState } from "react";
+
 export default function IconButton({ iconSrc, text }) {
+  const [userToken, setUserToken] = useState(null); // eslint-disable-line no-unused-vars
+
+  function handleLogin() {
+    chrome.runtime.sendMessage(
+      {
+        message: "userStatus",
+      },
+      (response) => {
+        if (response.message) {
+          setUserToken(response.message);
+          chrome.tabs.create({ url: "http://localhost:5174" });
+        }
+      }
+    );
+  }
   return (
     <button
       id="getUrl"
       className="w-[50%] h-[45px] bg-[#333] text-[#fff] rounded-[5px] flex justify-center items-center"
+      onClick={handleLogin}
     >
       <img
         src={iconSrc}

--- a/src/firebase/firebase-collection.js
+++ b/src/firebase/firebase-collection.js
@@ -1,6 +1,6 @@
 import { addDoc, collection } from "firebase/firestore";
 
-import { db } from "./firebase";
+import { db } from "../firebase";
 
 const users = collection(db, "users");
 const user = await addDoc(users, {

--- a/src/firebase/firebase-handler.js
+++ b/src/firebase/firebase-handler.js
@@ -1,6 +1,6 @@
 import { deleteDoc, doc, getDocs } from "firebase/firestore";
 
-import { groups, histories, user, users } from "./firebase-collection";
+import { groups, histories, user, users } from "./firebase/firebase-collection";
 
 const addHistory = async () => {
   user;

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -16,4 +16,4 @@ const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
 const db = getFirestore(app);
 
-export { db, analytics };
+export { app, db, analytics, firebaseConfig };


### PR DESCRIPTION
### 구현사진
<img width="1614" alt="image" src="https://github.com/user-attachments/assets/99c7232a-7d09-4f5a-952d-2a38b1daaae2" />

### 작업 내용
- 사용자를 식별하기 위하여 구글 로그인 연동 구현
- 로그인 유무를 파악하여 사용자 식별이 필요한 history 버튼과 history page 이동 버튼에 로그인 여부 조건을 걸어 미 로그인 시 위의 사진처럼 구글 로그인 팝업 노출
- 만일 로그인이 되어있다면 해당 버튼의 기능이 활성화
### 기존 계획과 달라진 부분(+이유와 함께)
- Firebase Authentication을 이용하여 구글 로그인 연동을 구현하려 했으나, 팝업창으로 사용될 추가 웹사이트가 필요하여 OAuth 2.0으로 구현
- 사용자 token은 현재 state로 관리하고 있으며, CRUD 보완 시 firebase에 저장하는 함수 구현 예정
### 차후 보완이 필요한 부분
- history page url 배포 후 도메인으로 변경 필요
### 구현한 내용(체크박스로 나타내기)
- [X] google login
- [X] 로그인이 되어 있으면 히스토리가 저장된 페이지로 이동
- [X] 미 로그인 시 로그인을 할 수 있는 페이지로 이동
- [ ] 사용자 id/accessToken firebase에 저장

### 리뷰어가 집중적으로 바줬으면 하는 것
참고사항 입니다.
- prop type과 unused로 인한 eslint 오류로 주석을 달아놓은 상황입니다. 이는 추후에 삭제하도록 하겠습니다.
- manifast파일의 client_id는 확장 프로그램의 client_id입니다. 이를 기반으로 구글 로그인 연동하여 사용자 token을 가져오고 있습니다.
### 관련 이슈
feat: 로그인 기능 #24
