### PR TITLE
feat: 스크롤 구현

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -57,8 +57,10 @@ chrome.storage.onChanged.addListener((changes, area) => {
       const newRules = [];
 
       for (let { newValue } of Object.values(changes)) {
-        const newLinkMaps = convertToLinkMap(newValue);
-        newRules.push(...createRules(newLinkMaps, 1));
+        if (newValue) {
+          const newLinkMaps = convertToLinkMap(newValue);
+          newRules.push(...createRules(newLinkMaps, 1));
+        }
       }
 
       chrome.declarativeNetRequest.updateDynamicRules({
@@ -67,4 +69,8 @@ chrome.storage.onChanged.addListener((changes, area) => {
       });
     });
   }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  chrome.storage.local.remove(`${tabId}`);
 });

--- a/background/background.js
+++ b/background/background.js
@@ -23,9 +23,13 @@ chrome.webNavigation.onCompleted.addListener((details) => {
   if (isGoogleSearch) {
     const tabId = details.tabId;
 
-    async function sendMessageToActiveTab(message) {
+    async function sendMessageToActiveTab(message, callbback = () => {}) {
       const response = await chrome.tabs.sendMessage(tabId, message);
 
+      callbback(response);
+    }
+
+    sendMessageToActiveTab("give-me-linkMap", (response) => {
       chrome.storage.local.set({ [`${tabId}`]: response }).then(() => {
         chrome.notifications.create({
           type: "basic",
@@ -43,9 +47,7 @@ chrome.webNavigation.onCompleted.addListener((details) => {
           message: data[tabId],
         });
       });
-    }
-
-    sendMessageToActiveTab("give-me-linkMap");
+    });
   }
 });
 

--- a/background/convertToLinkMap.js
+++ b/background/convertToLinkMap.js
@@ -1,0 +1,7 @@
+import { reviver } from "../content-script/mapToJosn";
+
+export function convertToLinkMap(storageData) {
+  const linkMap = JSON.parse(storageData, reviver);
+
+  return linkMap;
+}

--- a/background/convertToLinkMap.js
+++ b/background/convertToLinkMap.js
@@ -1,6 +1,9 @@
 import { reviver } from "../content-script/mapToJosn";
 
 export function convertToLinkMap(storageData) {
+  if (typeof storageData !== "string") {
+    throw TypeError("storageData에는 string을 제공해 주세요.");
+  }
   const linkMap = JSON.parse(storageData, reviver);
 
   return linkMap;

--- a/background/createRules.js
+++ b/background/createRules.js
@@ -1,0 +1,29 @@
+export function createRules(linkMaps, startID) {
+  const rules = [];
+  let currentIndex = startID;
+  linkMaps.forEach((value, link) => {
+    const { description } = value;
+
+    const textFragment = encodeURIComponent(description);
+    const redirectToUrl = link + "#:~:text=" + textFragment;
+
+    const rule = {
+      id: currentIndex,
+      condition: {
+        urlFilter: link,
+        resourceTypes: ["main_frame", "xmlhttprequest"],
+      },
+      action: {
+        type: "redirect",
+        redirect: {
+          url: redirectToUrl,
+        },
+      },
+    };
+    rules.push(rule);
+
+    currentIndex += 1;
+  });
+
+  return rules;
+}

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -10,7 +10,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const keywords = getSearchKeywords();
     const linkMap = setLinkMap(descriptionElements, keywords);
     const mapJson = JSON.stringify(linkMap, replacer);
+
     sendResponse(mapJson);
+
+    return true;
   }
 
   if (request.keywords) {
@@ -18,7 +21,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.goto) {
-    scroll(request.goto, request.currentScrollIndex, request.keyword);
+    const result = scroll(
+      request.goto,
+      request.currentScrollIndex,
+      request.keyword
+    );
+
+    sendResponse(result);
+
+    return true;
   }
 });
 
@@ -26,9 +37,19 @@ function scroll(goto, currentScrollIndex, keyword) {
   const keywordElements = Array.from(
     document.querySelectorAll(`[data-highlight="${keyword}"]`)
   );
+
+  if (
+    currentScrollIndex + goto > keywordElements.length - 1 ||
+    currentScrollIndex + goto < 0
+  ) {
+    return { isDone: false, message: "바운데리 값입니다." };
+  }
+
   keywordElements[currentScrollIndex + goto].scrollIntoView({
     behavior: "instant",
     block: "center",
   });
   keywordElements[currentScrollIndex + goto].style = `background:yellow`;
+
+  return { isDone: true };
 }

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -28,9 +28,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
-  if (request.goto) {
+  if (request.step) {
     const result = scroll(
-      request.goto,
+      request.step,
       request.currentScrollIndex,
       request.keyword
     );
@@ -44,19 +44,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 let defaultStyle = "";
 const UPDATED_STYLE = "background: yellow";
 
-function scroll(goto, currentScrollIndex, keyword) {
+function scroll(step, currentScrollIndex, keyword) {
   const keywordElements = Array.from(
     document.querySelectorAll(`[data-highlight="${keyword}"]`)
   );
 
   if (
-    currentScrollIndex + goto > keywordElements.length - 1 ||
-    currentScrollIndex + goto < 0
+    currentScrollIndex + step > keywordElements.length - 1 ||
+    currentScrollIndex + step < 0
   ) {
     return { isDone: false, message: "바운데리 값입니다." };
   }
 
-  if (goto === 0) {
+  if (step === 0) {
     defaultStyle = keywordElements[0].style.cssText;
     keywordElements[0].scrollIntoView({
       behavior: "instant",
@@ -67,11 +67,11 @@ function scroll(goto, currentScrollIndex, keyword) {
     return { isDone: true };
   }
 
-  keywordElements[currentScrollIndex + goto].scrollIntoView({
+  keywordElements[currentScrollIndex + step].scrollIntoView({
     behavior: "instant",
     block: "center",
   });
-  keywordElements[currentScrollIndex + goto].style = UPDATED_STYLE;
+  keywordElements[currentScrollIndex + step].style = UPDATED_STYLE;
   keywordElements[currentScrollIndex].style = defaultStyle;
 
   return { isDone: true };

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -14,19 +14,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.keywords) {
-    console.log("키워드 받음", request.keywords);
     highlightKeywords(request.keywords, document.body, getLeafTargetElements);
   }
 
-  if (request.goto === "next") {
-    start(request.goto);
-  }
-
-  if (request.goto === "prev") {
-    start(request.goto);
+  if (request.goto) {
+    scroll(request.goto, request.currentScrollIndex, request.keyword);
   }
 });
 
-function start(goto) {
-  console.log(`${goto} 작동`);
+function scroll(goto, currentScrollIndex, keyword) {
+  const keywordElements = Array.from(
+    document.querySelectorAll(`[data-highlight="${keyword}"]`)
+  );
+  keywordElements[currentScrollIndex + goto].scrollIntoView({
+    behavior: "instant",
+    block: "center",
+  });
+  keywordElements[currentScrollIndex + goto].style = `background:yellow`;
 }

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -20,6 +20,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     highlightKeywords(request.keywords, document.body, getLeafTargetElements);
   }
 
+  if (request.init) {
+    const result = scroll(0, 0, request.keyword);
+
+    sendResponse(result);
+
+    return true;
+  }
+
   if (request.goto) {
     const result = scroll(
       request.goto,
@@ -33,6 +41,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
+let defaultStyle = "";
+const UPDATED_STYLE = "background: yellow";
+
 function scroll(goto, currentScrollIndex, keyword) {
   const keywordElements = Array.from(
     document.querySelectorAll(`[data-highlight="${keyword}"]`)
@@ -45,11 +56,23 @@ function scroll(goto, currentScrollIndex, keyword) {
     return { isDone: false, message: "바운데리 값입니다." };
   }
 
+  if (goto === 0) {
+    defaultStyle = keywordElements[0].style.cssText;
+    keywordElements[0].scrollIntoView({
+      behavior: "instant",
+      block: "center",
+    });
+    keywordElements[0].style = UPDATED_STYLE;
+
+    return { isDone: true };
+  }
+
   keywordElements[currentScrollIndex + goto].scrollIntoView({
     behavior: "instant",
     block: "center",
   });
-  keywordElements[currentScrollIndex + goto].style = `background:yellow`;
+  keywordElements[currentScrollIndex + goto].style = UPDATED_STYLE;
+  keywordElements[currentScrollIndex].style = defaultStyle;
 
   return { isDone: true };
 }

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -4,16 +4,29 @@ import { highlightKeywords } from "./highlight";
 import { SELECTOR, getDescriptionElements, setLinkMap } from "./linkMap";
 import { replacer } from "./mapToJosn";
 
-const keywords = getSearchKeywords();
-
-highlightKeywords(keywords, document.body, getLeafTargetElements);
-
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  const descriptionElements = getDescriptionElements(SELECTOR);
-  const linkMap = setLinkMap(descriptionElements, keywords);
-
   if (request === "give-me-linkMap") {
+    const descriptionElements = getDescriptionElements(SELECTOR);
+    const keywords = getSearchKeywords();
+    const linkMap = setLinkMap(descriptionElements, keywords);
     const mapJson = JSON.stringify(linkMap, replacer);
     sendResponse(mapJson);
   }
+
+  if (request.keywords) {
+    console.log("키워드 받음", request.keywords);
+    highlightKeywords(request.keywords, document.body, getLeafTargetElements);
+  }
+
+  if (request.goto === "next") {
+    start(request.goto);
+  }
+
+  if (request.goto === "prev") {
+    start(request.goto);
+  }
 });
+
+function start(goto) {
+  console.log(`${goto} 작동`);
+}

--- a/content-script/highlight.js
+++ b/content-script/highlight.js
@@ -62,6 +62,7 @@ function setHighlight(keyword, targetElement, color) {
         const highlightedSpan = document.createElement("span");
         highlightedSpan.textContent = keyword;
         highlightedSpan.style = `background:${color}`;
+        highlightedSpan.dataset.highlight = keyword;
         parentElement.insertBefore(highlightedSpan, currentTextNode);
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1852,9 +1852,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
-      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
+      "integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
       "cpu": [
         "arm"
       ],
@@ -1866,9 +1866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
-      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
+      "integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
       "cpu": [
         "arm64"
       ],
@@ -1880,9 +1880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
-      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
+      "integrity": "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==",
       "cpu": [
         "arm64"
       ],
@@ -1894,9 +1894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
-      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
+      "integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
       "cpu": [
         "x64"
       ],
@@ -1908,9 +1908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
-      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
+      "integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
       "cpu": [
         "arm64"
       ],
@@ -1922,9 +1922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
-      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
+      "integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
       "cpu": [
         "x64"
       ],
@@ -1936,9 +1936,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
-      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
+      "integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
       "cpu": [
         "arm"
       ],
@@ -1950,9 +1950,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
-      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
+      "integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
       "cpu": [
         "arm"
       ],
@@ -1964,9 +1964,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
-      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
+      "integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
       "cpu": [
         "arm64"
       ],
@@ -1978,9 +1978,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
-      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
+      "integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
       "cpu": [
         "arm64"
       ],
@@ -1992,9 +1992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
-      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
+      "integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
       "cpu": [
         "loong64"
       ],
@@ -2006,9 +2006,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
-      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
+      "integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2020,9 +2020,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
-      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
+      "integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
       "cpu": [
         "riscv64"
       ],
@@ -2034,9 +2034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
-      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
+      "integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
       "cpu": [
         "s390x"
       ],
@@ -2048,9 +2048,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
-      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
+      "integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
       "cpu": [
         "x64"
       ],
@@ -2062,9 +2062,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
-      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
+      "integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
       "cpu": [
         "x64"
       ],
@@ -2076,9 +2076,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
-      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
+      "integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
       "cpu": [
         "arm64"
       ],
@@ -2090,9 +2090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
-      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
+      "integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
       "cpu": [
         "ia32"
       ],
@@ -2104,9 +2104,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
-      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
+      "integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
       "cpu": [
         "x64"
       ],
@@ -2118,9 +2118,9 @@
       ]
     },
     "node_modules/@tanstack/eslint-plugin-query": {
-      "version": "5.62.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.62.16.tgz",
-      "integrity": "sha512-VhnHSQ/hc62olLzGhlLJ4BJGWynwjs3cDMsByasKJ3zjW1YZ+6raxOv0gHHISm+VEnAY42pkMowmSWrXfL4NTw==",
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.64.2.tgz",
+      "integrity": "sha512-Xq7jRYvNtGMHjQEGUZLHgEMNB59hgTlqdmKor6cdJ6CMZ/nwmBGpnlr/dcHden7W7BPCdBVN4PWMZBICWvCNQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.64.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.1.tgz",
-      "integrity": "sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==",
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.2.tgz",
+      "integrity": "sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2145,12 +2145,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.64.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.1.tgz",
-      "integrity": "sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==",
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.2.tgz",
+      "integrity": "sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.64.1"
+        "@tanstack/query-core": "5.64.2"
       },
       "funding": {
         "type": "github",
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001692",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -5919,9 +5919,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.31.0.tgz",
+      "integrity": "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5935,25 +5935,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.30.1",
-        "@rollup/rollup-android-arm64": "4.30.1",
-        "@rollup/rollup-darwin-arm64": "4.30.1",
-        "@rollup/rollup-darwin-x64": "4.30.1",
-        "@rollup/rollup-freebsd-arm64": "4.30.1",
-        "@rollup/rollup-freebsd-x64": "4.30.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
-        "@rollup/rollup-linux-arm64-musl": "4.30.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-musl": "4.30.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
-        "@rollup/rollup-win32-x64-msvc": "4.30.1",
+        "@rollup/rollup-android-arm-eabi": "4.31.0",
+        "@rollup/rollup-android-arm64": "4.31.0",
+        "@rollup/rollup-darwin-arm64": "4.31.0",
+        "@rollup/rollup-darwin-x64": "4.31.0",
+        "@rollup/rollup-freebsd-arm64": "4.31.0",
+        "@rollup/rollup-freebsd-x64": "4.31.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.31.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.31.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.31.0",
+        "@rollup/rollup-linux-arm64-musl": "4.31.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.31.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.31.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.31.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-musl": "4.31.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.31.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.31.0",
+        "@rollup/rollup-win32-x64-msvc": "4.31.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -27,7 +27,9 @@
     "unlimitedStorage",
     "storage",
     "webNavigation",
-    "notifications"
+    "notifications",
+    "declarativeNetRequest",
+    "declarativeNetRequestFeedback"
   ],
   "host_permissions": ["<all_urls>"],
   "commands": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,10 @@ import SearchSection from "./components/search-section";
 const queryClient = new QueryClient();
 
 function App() {
+  chrome.storage.local.get(null).then((data) => {
+    console.log(data); // 됨
+  });
+
   return (
     <QueryClientProvider client={queryClient}>
       <HistorySection />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,10 +7,6 @@ import SearchSection from "./components/search-section";
 const queryClient = new QueryClient();
 
 function App() {
-  chrome.storage.local.get(null).then((data) => {
-    console.log(data); // 됨
-  });
-
   return (
     <QueryClientProvider client={queryClient}>
       <HistorySection />

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -1,8 +1,22 @@
+import { useState } from "react";
+
 export function SearchSectionInput() {
+  const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
+
   function handleArrowClick(goto) {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       const activeTab = tabs[0];
-      chrome.tabs.sendMessage(activeTab.id, { goto });
+      chrome.tabs.sendMessage(activeTab.id, {
+        goto: goto === "next" ? 1 : -1,
+        currentScrollIndex,
+        keyword: "banana",
+      });
+
+      if (goto === "next") {
+        setCurrentScrollIndex(currentScrollIndex + 1);
+      } else {
+        setCurrentScrollIndex(currentScrollIndex - 1);
+      }
     });
   }
 

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -4,6 +4,20 @@ import { useState } from "react";
 export function SearchSectionInput({ currentKeyword }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
 
+  async function handleSearchClick() {
+    const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
+
+    const activeTab = tabs[0];
+    const response = await chrome.tabs.sendMessage(activeTab.id, {
+      init: true,
+      keyword: currentKeyword,
+    });
+
+    if (response.isDone) {
+      setCurrentScrollIndex(0);
+    }
+  }
+
   async function handleArrowClick(goto) {
     const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
 
@@ -36,7 +50,10 @@ export function SearchSectionInput({ currentKeyword }) {
         </span>
         <button onClick={() => handleArrowClick("prev")}>↑</button>
         <button onClick={() => handleArrowClick("next")}>↓</button>
-        <button className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full">
+        <button
+          onClick={() => handleSearchClick()}
+          className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full"
+        >
           <img
             src="./search_icon.png"
             alt="search_icon"

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -1,4 +1,11 @@
 export function SearchSectionInput() {
+  function handleArrowClick(goto) {
+    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+      const activeTab = tabs[0];
+      chrome.tabs.sendMessage(activeTab.id, { goto });
+    });
+  }
+
   return (
     <>
       <input
@@ -10,8 +17,8 @@ export function SearchSectionInput() {
         <span className="text-[#ccc] font-extralight leading-[50px]">
           Total
         </span>
-        <button>↑</button>
-        <button>↓</button>
+        <button onClick={() => handleArrowClick("prev")}>↑</button>
+        <button onClick={() => handleArrowClick("next")}>↓</button>
         <button className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full">
           <img
             src="./search_icon.png"

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -18,18 +18,18 @@ export function SearchSectionInput({ currentKeyword }) {
     }
   }
 
-  async function handleArrowClick(goto) {
+  async function handleArrowClick(direction) {
     const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
 
     const activeTab = tabs[0];
     const response = await chrome.tabs.sendMessage(activeTab.id, {
-      goto: goto === "next" ? 1 : -1,
+      step: direction === "next" ? 1 : -1,
       currentScrollIndex,
       keyword: currentKeyword,
     });
 
     if (response.isDone) {
-      if (goto === "next") {
+      if (direction === "next") {
         setCurrentScrollIndex(currentScrollIndex + 1);
       } else {
         setCurrentScrollIndex(currentScrollIndex - 1);

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -1,6 +1,7 @@
+import PropTypes from "prop-types";
 import { useState } from "react";
 
-export function SearchSectionInput() {
+export function SearchSectionInput({ currentKeyword }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
 
   function handleArrowClick(goto) {
@@ -9,7 +10,7 @@ export function SearchSectionInput() {
       chrome.tabs.sendMessage(activeTab.id, {
         goto: goto === "next" ? 1 : -1,
         currentScrollIndex,
-        keyword: "banana",
+        keyword: currentKeyword,
       });
 
       if (goto === "next") {
@@ -44,3 +45,7 @@ export function SearchSectionInput() {
     </>
   );
 }
+
+SearchSectionInput.propTypes = {
+  currentKeyword: PropTypes.string.isRequired,
+};

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -4,21 +4,23 @@ import { useState } from "react";
 export function SearchSectionInput({ currentKeyword }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
 
-  function handleArrowClick(goto) {
-    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      const activeTab = tabs[0];
-      chrome.tabs.sendMessage(activeTab.id, {
-        goto: goto === "next" ? 1 : -1,
-        currentScrollIndex,
-        keyword: currentKeyword,
-      });
+  async function handleArrowClick(goto) {
+    const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
 
+    const activeTab = tabs[0];
+    const response = await chrome.tabs.sendMessage(activeTab.id, {
+      goto: goto === "next" ? 1 : -1,
+      currentScrollIndex,
+      keyword: currentKeyword,
+    });
+
+    if (response.isDone) {
       if (goto === "next") {
         setCurrentScrollIndex(currentScrollIndex + 1);
       } else {
         setCurrentScrollIndex(currentScrollIndex - 1);
       }
-    });
+    }
   }
 
   return (

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -13,8 +13,8 @@ export default function SearchSection() {
   async function handleKeywordClick() {
     setIsKeywordOn(!isKeywordOn);
     if (!isKeywordOn) {
-      const data = await chrome.storage.local.get(null);
-      const linkMapJsons = Object.values(data);
+      const tabIdToLinkMapJson = await chrome.storage.local.get(null);
+      const linkMapJsons = Object.values(tabIdToLinkMapJson);
       const linkMap = convertToLinkMap(linkMapJsons[0]);
       const mapIterator = linkMap.values();
       for (const { keywords } of mapIterator) {

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -1,14 +1,45 @@
+import { useState } from "react";
+
+import { convertToLinkMap } from "../../../background/convertToLinkMap";
 import TextButton from "../shared/TextButton";
 import { KeywordGroup } from "./KetwordGroup";
 import { SearchSectionInput } from "./SearchSectionInput";
 
 export default function SearchSection() {
+  const [isKeywordOn, setIsKeywordOn] = useState(false);
+  const [keywords, setKeywords] = useState([]);
+
+  async function handleKeywordClick() {
+    if (!isKeywordOn) {
+      const data = await chrome.storage.local.get(null);
+      const linkMapJsons = Object.values(data);
+      const linkMap = convertToLinkMap(linkMapJsons[0]);
+      const mapIterator = linkMap.values();
+      for (const { keywords } of mapIterator) {
+        setKeywords(keywords);
+        setIsKeywordOn(!isKeywordOn);
+        break;
+      }
+    }
+  }
+
+  if (keywords.length > 0) {
+    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+      const activeTab = tabs[0];
+      chrome.tabs.sendMessage(activeTab.id, { keywords });
+      console.log("키워드 보냄");
+    });
+  }
+
   return (
     <>
       <SearchSectionInput />
       <div className="flex gap-[15px]">
         <TextButton text={"Descrition"} />
-        <TextButton text={"keyword"} />
+        <TextButton
+          text={"keyword"}
+          onClick={() => handleKeywordClick()}
+        />
       </div>
       <KeywordGroup />
     </>

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -18,6 +18,8 @@ export default function SearchSection() {
       const linkMap = convertToLinkMap(linkMapJsons[0]);
       const mapIterator = linkMap.values();
       for (const { keywords } of mapIterator) {
+        // eslint-disable-next-line no-debugger
+        debugger;
         setKeywords(keywords);
         setCurrentKeyword(keywords[0]);
 

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -18,8 +18,6 @@ export default function SearchSection() {
       const linkMap = convertToLinkMap(linkMapJsons[0]);
       const mapIterator = linkMap.values();
       for (const { keywords } of mapIterator) {
-        // eslint-disable-next-line no-debugger
-        debugger;
         setKeywords(keywords);
         setCurrentKeyword(keywords[0]);
 

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -8,6 +8,7 @@ import { SearchSectionInput } from "./SearchSectionInput";
 export default function SearchSection() {
   const [isKeywordOn, setIsKeywordOn] = useState(false);
   const [keywords, setKeywords] = useState([]);
+  const [currentKeyword, setCurrentKeyword] = useState("");
 
   async function handleKeywordClick() {
     setIsKeywordOn(!isKeywordOn);
@@ -18,6 +19,7 @@ export default function SearchSection() {
       const mapIterator = linkMap.values();
       for (const { keywords } of mapIterator) {
         setKeywords(keywords);
+        setCurrentKeyword(keywords[0]);
 
         break;
       }
@@ -33,7 +35,7 @@ export default function SearchSection() {
 
   return (
     <>
-      <SearchSectionInput />
+      <SearchSectionInput currentKeyword={currentKeyword} />
       <div className="flex gap-[15px]">
         <TextButton text={"Descrition"} />
         <TextButton
@@ -41,7 +43,10 @@ export default function SearchSection() {
           onClick={() => handleKeywordClick()}
         />
       </div>
-      <KeywordGroup />
+      <KeywordGroup
+        currentKeyword={currentKeyword}
+        keywords={keywords}
+      />
     </>
   );
 }

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -10,6 +10,7 @@ export default function SearchSection() {
   const [keywords, setKeywords] = useState([]);
 
   async function handleKeywordClick() {
+    setIsKeywordOn(!isKeywordOn);
     if (!isKeywordOn) {
       const data = await chrome.storage.local.get(null);
       const linkMapJsons = Object.values(data);
@@ -17,7 +18,7 @@ export default function SearchSection() {
       const mapIterator = linkMap.values();
       for (const { keywords } of mapIterator) {
         setKeywords(keywords);
-        setIsKeywordOn(!isKeywordOn);
+
         break;
       }
     }
@@ -27,7 +28,6 @@ export default function SearchSection() {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       const activeTab = tabs[0];
       chrome.tabs.sendMessage(activeTab.id, { keywords });
-      console.log("키워드 보냄");
     });
   }
 

--- a/src/components/shared/TextButton.jsx
+++ b/src/components/shared/TextButton.jsx
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
-export default function TextButton({ text }) {
+export default function TextButton({ text, onClick }) {
   return (
-    <button className="bg-[#333] text-[#fff] border w-[50%] py-[10px] rounded-full">
+    <button
+      onClick={onClick}
+      className="bg-[#333] text-[#fff] border w-[50%] py-[10px] rounded-full"
+    >
       {text}
     </button>
   );


### PR DESCRIPTION
### 구현사진
![Jan-21-2025 14-27-59](https://github.com/user-attachments/assets/ba492af4-9b41-4ad7-9a5c-47e6ecf2259b)

### 작업 내용
- 구글 검색 페이지에 있는 링크 클릭 시, 열린 페이지의 description 영역으로 스크롤
- 사이드패널 내부의 화살표 버튼을 클릭했을 때, 다음/이전 키워드 위치로 스크롤
- 사용자가 스크롤 처음과 끝에 도달 시 화살표 버튼이 작동하지 않도록 방지했습니다.
- 사용자가 직관적으로 스크롤 상황을 볼 수 있도록, 현재 스크롤 위치의 키워드만 배경색이 변경되도록 했습니다.

### 기존 계획과 달라진 부분(+이유와 함께)
- description이 페이지 내부에 없을 경우 사용자에게 alert을 보여주도록 구현할 예정이었으나, 사용자는 이미 전체 keyword 토글 버튼으로 keyword들이 하이라이팅되도록 만들 수 있는 편의 기능을 사용할 수 있으므로 MVP 구현 우선순위가 높지 않다고 회의를 통해 다시 상정됨
- 스크롤 위치 표시는 현재 스크롤로 인해 보완이 되는 부분이 있으며 다른 테스크들 보다 우선순위가 높지 않다고 회의를 통해 다시 상정됨
- id를 위해 uuid 라이브러리를 설치할 예정이었으나, 숫자인 id가 필요하고 기타 조건에 맞지 않아 라이브러리를 설치하지 않았습니다.

### 차후 보완이 필요한 부분
- 이미지가 나중에 로드되면 하이라이트 된 부분이 밑으로 밀려나는 현상
- 현재 키워드 위치의 색은 임의로 노란색을 선택해 놓았습니다. 

### 구현한 내용(체크박스로 나타내기)
- [x] 구글 검색 페이지에 있는 text 링크를 눌렀을 때, 열린 페이지의 description 영역으로 스크롤
- [ ] 만약 페이지 내 description이 없을 경우 alert로 해당 정보가 없다고 알림
- [x] 사이드패널 내부의 화살표 버튼을 클릭했을 때, 다음/이전 키워드 위치로 스크롤
- [ ] 스크롤 위치 표시

### 리뷰어가 집중적으로 바줬으면 하는 것
- 컨벤션이 통일 여부
- 고려사항 : 스크롤을 시행시키는 것은 간단했으나 그 이전에 extension의 background, content-script, side-panel 각 계층을 넘나드는 등 사전 준비과정의 코드가 생각보다 많아졌습니다. 양해 부탁드립니다. (__)

### 관련 이슈
Closes #26 
