### PR TITLE
feat: history section 구현

### DIFF
--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -1,10 +1,8 @@
-/* eslint-disable no-unused-vars */
-import { useState } from "react";
-
+import { addDefaultGroup, addHistory } from "../../firebase/CRUD";
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection() {
-  const [userToken, setUserToken] = useState(null);
+  let userToken = "";
   const options = {
     year: "numeric",
     month: "numeric",
@@ -16,6 +14,11 @@ export default function HistorySection() {
   const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
     new Date()
   );
+  const groupTitle = "New Keyword Group";
+  const favicon = "favicon";
+  const siteName = "구글";
+  const url = "google.com";
+  const keywords = { apple: 3, banana: 15 };
 
   function handleMovePage() {
     chrome.runtime.sendMessage(
@@ -24,7 +27,7 @@ export default function HistorySection() {
       },
       (response) => {
         if (response.message) {
-          setUserToken(response.message);
+          userToken = response.message;
           chrome.tabs.create({ url: "http://localhost:5174" });
         }
       }
@@ -38,7 +41,17 @@ export default function HistorySection() {
       },
       (response) => {
         if (response.message) {
-          setUserToken(response.message);
+          userToken = response.message;
+          addDefaultGroup(userToken);
+          addHistory(
+            userToken,
+            groupTitle,
+            favicon,
+            siteName,
+            url,
+            currentDate,
+            keywords
+          );
         }
       }
     );

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -1,6 +1,24 @@
+import { useState } from "react";
+
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection() {
+  const [userToken, setUserToken] = useState(null); // eslint-disable-line no-unused-vars
+
+  function handleMovePage() {
+    chrome.runtime.sendMessage(
+      {
+        message: "userStatus",
+      },
+      (response) => {
+        if (response.message) {
+          setUserToken(response.message);
+          chrome.tabs.create({ url: "http://localhost:5174" });
+        }
+      }
+    );
+  }
+
   return (
     <div
       id="urls"
@@ -13,6 +31,7 @@ export default function HistorySection() {
       <IconButton
         iconSrc={"./page_Icon.png"}
         text={"History Page"}
+        onClick={handleMovePage}
       />
     </div>
   );

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -1,9 +1,21 @@
+/* eslint-disable no-unused-vars */
 import { useState } from "react";
 
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection() {
-  const [userToken, setUserToken] = useState(null); // eslint-disable-line no-unused-vars
+  const [userToken, setUserToken] = useState(null);
+  const options = {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+  };
+  const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
+    new Date()
+  );
 
   function handleMovePage() {
     chrome.runtime.sendMessage(
@@ -19,6 +31,19 @@ export default function HistorySection() {
     );
   }
 
+  function handleAddHistory() {
+    chrome.runtime.sendMessage(
+      {
+        message: "userStatus",
+      },
+      (response) => {
+        if (response.message) {
+          setUserToken(response.message);
+        }
+      }
+    );
+  }
+
   return (
     <div
       id="urls"
@@ -27,6 +52,7 @@ export default function HistorySection() {
       <IconButton
         iconSrc={"./history_icon.png"}
         text={"History"}
+        onClick={handleAddHistory}
       />
       <IconButton
         iconSrc={"./page_Icon.png"}

--- a/src/components/shared/IconButton.jsx
+++ b/src/components/shared/IconButton.jsx
@@ -1,27 +1,11 @@
 import PropTypes from "prop-types";
-import { useState } from "react";
 
-export default function IconButton({ iconSrc, text }) {
-  const [userToken, setUserToken] = useState(null); // eslint-disable-line no-unused-vars
-
-  function handleLogin() {
-    chrome.runtime.sendMessage(
-      {
-        message: "userStatus",
-      },
-      (response) => {
-        if (response.message) {
-          setUserToken(response.message);
-          chrome.tabs.create({ url: "http://localhost:5174" });
-        }
-      }
-    );
-  }
+export default function IconButton({ iconSrc, text, onClick }) {
   return (
     <button
       id="getUrl"
       className="w-[50%] h-[45px] bg-[#333] text-[#fff] rounded-[5px] flex justify-center items-center"
-      onClick={handleLogin}
+      onClick={onClick}
     >
       <img
         src={iconSrc}
@@ -36,4 +20,5 @@ export default function IconButton({ iconSrc, text }) {
 IconButton.propTypes = {
   text: PropTypes.string.isRequired,
   iconSrc: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };

--- a/src/firebase/CRUD.js
+++ b/src/firebase/CRUD.js
@@ -16,13 +16,21 @@ async function addGroup(token, title) {
   });
 }
 
-async function addHistory(token, title, faviconSrc, siteTitle, url, keywords) {
+async function addHistory(
+  token,
+  title,
+  faviconSrc,
+  siteTitle,
+  url,
+  createdTime,
+  keywords
+) {
   const subCollection = doc(collection(db, token, title, "histories"));
   await setDoc(subCollection, {
     faviconSrc,
     siteTitle,
     url,
-    createdTime: "",
+    createdTime,
     keywords,
   });
 }

--- a/src/firebase/CRUD.js
+++ b/src/firebase/CRUD.js
@@ -9,8 +9,15 @@ import {
 
 import { db } from "./firebase";
 
+async function addDefaultGroup(token) {
+  const rootCollection = doc(db, token, "New Keyword Group");
+  await setDoc(rootCollection, {
+    title: "New Keyword Group",
+  });
+}
+
 async function addGroup(token, title) {
-  const rootCollection = doc(db, token);
+  const rootCollection = doc(collection(db, token));
   await setDoc(rootCollection, {
     title,
   });
@@ -18,14 +25,14 @@ async function addGroup(token, title) {
 
 async function addHistory(
   token,
-  title,
+  titleId,
   faviconSrc,
   siteTitle,
   url,
   createdTime,
   keywords
 ) {
-  const subCollection = doc(collection(db, token, title, "histories"));
+  const subCollection = doc(collection(db, token, titleId, "histories"));
   await setDoc(subCollection, {
     faviconSrc,
     siteTitle,
@@ -68,6 +75,7 @@ async function deleteHistory(token, title, historyId) {
 }
 
 export {
+  addDefaultGroup,
   addGroup,
   addHistory,
   getGroups,


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/5d60550d-cf09-42ce-a999-c81b3cbcf205

<img width="931" alt="image" src="https://github.com/user-attachments/assets/a5288dd1-83ff-4860-92e2-2df51149518c" />

### 작업 내용
- History 저장 버튼 = 사용자가 현재 보고있는 사이트 url 및 검색했던 쿼리를 저장
- History page 이동 버튼 = 사용자가 저장한 history list를 볼 수 있는 사이트로 안내
- +기능 구현의 로직에 따라 CRUD 수정이 필요하여 일부 수정
### 기존 계획과 달라진 부분(+이유와 함께)
- history저장한도는 차후 실제 배포 시 사용량을 체크하면서 제한 기준을 정하는 것이 좋다고 판단되어 현재는 따로 제한을 두지 않았습니다.
### 차후 보완이 필요한 부분
- 실제 필요한 데이터를 반환하는 함수를 삽입하여 재테스트가 필요합니다.
-> 다른 테스크에서 위에서 언급한 함수 로직 구현이 아직 완료되지 않아, 현재는 mock data를 이용하여 저장하는 기능이 정상적으로 구현되는지 확인하였습니다.
### 구현한 내용(체크박스로 나타내기)
- [X] History page 이동 기능(미 로그인 상태 시 구글 로그인 팝업 노출)
- [X] 미 로그인 상태로 History 저장 버튼 클릭 시 구글 로그인 팝업 노출
- [X] History 저장 버튼을 클릭했을 때 history 저장 -> 해당 사이트 favicon, 사이트 이름, 사이트 주소(url), 저장 시간, 키워드, 키워드 노출 횟수
- [ ] History 저장 한도개수 지정(최대 50개)
### 리뷰어가 집중적으로 바줬으면 하는 것
- index파일의 17~21번 줄은 mockdata이므로 참고하시기 바랍니다.
- 위에서 언급한대로 저장한 history는 처음엔 무조건 defaultGroup으로 가야해서 CURD를 일부 수정하였습니다.
### 관련 이슈
feat: history section 구현 #28 
