### PR TITLE
feat: search section 내 search 기능 구현

### DIFF
--- a/content-script/content.js
+++ b/content-script/content.js
@@ -19,14 +19,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.keywords) {
-    highlightKeywords(request.keywords, document.body, getLeafTargetElements);
+    const newKeywords = request.keywords.filter(
+      (keyword) => !document.querySelector(`[data-highlight="${keyword}"]`)
+    );
+
+    highlightKeywords(newKeywords, document.body, getLeafTargetElements);
   }
 
   if (request.message === "get-keyword-element-total-count") {
+    const keywordElements = getKeywordElements(request.keyword);
+
     sendResponse({
-      totalCount: document.querySelectorAll(
-        `[data-highlight="${request.keyword}"]`
-      ).length,
+      totalCount: keywordElements.length,
     });
 
     return true;
@@ -44,6 +48,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 });
+
+function getKeywordElements(keyword) {
+  return document.querySelectorAll(`[data-highlight="${keyword}"]`);
+}
 
 let defaultStyle = "";
 const UPDATED_STYLE = "background: rgb(76, 168, 128)";

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -24,14 +24,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     );
 
     highlightKeywords(newKeywords, document.body, getLeafTargetElements);
-  }
 
-  if (request.message === "get-keyword-element-total-count") {
-    const keywordElements = getKeywordElements(request.keyword);
-
-    sendResponse({
-      totalCount: keywordElements.length,
+    const result = request.keywords.map((keyword) => {
+      return {
+        keyword,
+        count: document.querySelectorAll(`[data-highlight="${keyword}"]`)
+          .length,
+      };
     });
+
+    sendResponse(result);
 
     return true;
   }
@@ -48,10 +50,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 });
-
-function getKeywordElements(keyword) {
-  return document.querySelectorAll(`[data-highlight="${keyword}"]`);
-}
 
 let defaultStyle = "";
 const UPDATED_STYLE = "background: rgb(76, 168, 128)";

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -24,16 +24,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
   if (request.message === "get-keyword-element-total-count") {
     sendResponse({
-      totalCount: document.querySelectorAll(`[data-highlight="${request.keyword}"]`).length
+      totalCount: document.querySelectorAll(
+        `[data-highlight="${request.keyword}"]`
+      ).length,
     });
-
-    return true;
-  }
-
-  if (request.init) {
-    const result = scroll(0, 0, request.keyword);
-
-    sendResponse(result);
 
     return true;
   }
@@ -52,12 +46,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 let defaultStyle = "";
-const UPDATED_STYLE = "background: yellow";
+const UPDATED_STYLE = "background: rgb(76, 168, 128)";
 
 function scroll(step, currentScrollIndex, keyword) {
   const keywordElements = Array.from(
     document.querySelectorAll(`[data-highlight="${keyword}"]`)
   );
+
+  if (currentScrollIndex === -1) {
+    defaultStyle = keywordElements[0].style.cssText;
+  }
 
   if (
     currentScrollIndex + step > keywordElements.length - 1 ||
@@ -66,23 +64,15 @@ function scroll(step, currentScrollIndex, keyword) {
     return { isDone: false, message: "바운데리 값입니다." };
   }
 
-  if (step === 0) {
-    defaultStyle = keywordElements[0].style.cssText;
-    keywordElements[0].scrollIntoView({
-      behavior: "instant",
-      block: "center",
-    });
-    keywordElements[0].style = UPDATED_STYLE;
-
-    return { isDone: true };
-  }
-
   keywordElements[currentScrollIndex + step].scrollIntoView({
     behavior: "instant",
     block: "center",
   });
-  keywordElements[currentScrollIndex + step].style = UPDATED_STYLE;
-  keywordElements[currentScrollIndex].style = defaultStyle;
 
-  return { isDone: true };
+  keywordElements[currentScrollIndex + step].style = UPDATED_STYLE;
+  if (currentScrollIndex !== -1) {
+    keywordElements[currentScrollIndex].style = defaultStyle;
+  }
+
+  return { isDone: true, newIndex: currentScrollIndex + step };
 }

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -11,6 +11,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const linkMap = setLinkMap(descriptionElements, keywords);
     const mapJson = JSON.stringify(linkMap, replacer);
 
+    highlightKeywords(keywords, document.body, getLeafTargetElements);
+
     sendResponse(mapJson);
 
     return true;

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -22,6 +22,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     highlightKeywords(request.keywords, document.body, getLeafTargetElements);
   }
 
+  if (request.message === "get-keyword-element-total-count") {
+    sendResponse({
+      totalCount: document.querySelectorAll(`[data-highlight="${request.keyword}"]`).length
+    });
+
+    return true;
+  }
+
   if (request.init) {
     const result = scroll(0, 0, request.keyword);
 

--- a/src/components/search-section/KeywordGroup.jsx
+++ b/src/components/search-section/KeywordGroup.jsx
@@ -1,6 +1,8 @@
+import PropTypes from "prop-types";
+
 import TextButton from "../shared/TextButton";
 
-export function KeywordGroup() {
+export function KeywordGroup({ group }) {
   return (
     <>
       <div>
@@ -8,13 +10,13 @@ export function KeywordGroup() {
           Keyword Group
         </p>
         <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-center grid grid-cols-3 gap-[15px] px-[10px] py-[20px]">
-          {Array(14).map((_, index) => {
+          {group.map((keyword, index) => {
             return (
               <li
                 key={index}
                 className="bg-[#333] text-[#fff] text-xs py-[10px] rounded-full"
               >
-                <TextButton text={`keyword ${index}`} />
+                <TextButton text={keyword} />
               </li>
             );
           })}
@@ -23,3 +25,8 @@ export function KeywordGroup() {
     </>
   );
 }
+
+KeywordGroup.propTypes = {
+  group: PropTypes.array.isRequired,
+  setCurrentKeyword: PropTypes.func.isRequired,
+};

--- a/src/components/search-section/KeywordGroup.jsx
+++ b/src/components/search-section/KeywordGroup.jsx
@@ -2,7 +2,8 @@ import PropTypes from "prop-types";
 
 import TextButton from "../shared/TextButton";
 
-export function KeywordGroup({ group }) {
+export function KeywordGroup({ countsPerKeywords }) {
+  const existingKeywords = countsPerKeywords.map(({ keyword }) => keyword);
   return (
     <>
       <div>
@@ -10,7 +11,7 @@ export function KeywordGroup({ group }) {
           Keyword Group
         </p>
         <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-center grid grid-cols-3 gap-[15px] px-[10px] py-[20px]">
-          {group.map((keyword, index) => {
+          {existingKeywords.map((keyword, index) => {
             return (
               <li
                 key={index}
@@ -27,6 +28,5 @@ export function KeywordGroup({ group }) {
 }
 
 KeywordGroup.propTypes = {
-  group: PropTypes.array.isRequired,
-  setCurrentKeyword: PropTypes.func.isRequired,
+  countsPerKeywords: PropTypes.array.isRequired,
 };

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -22,7 +22,7 @@ export function SearchSectionInput({ currentKeyword, handleEnter, group }) {
   }
 
   useEffect(() => {
-    async function getKeywordElementTotalCount(keyword) {
+    async function getKeywordElementTotalCount(keywordInInput) {
       const tabs = await chrome.tabs.query({
         currentWindow: true,
         active: true,
@@ -30,7 +30,7 @@ export function SearchSectionInput({ currentKeyword, handleEnter, group }) {
       const activeTab = tabs[0];
       const response = await chrome.tabs.sendMessage(activeTab.id, {
         message: "get-keyword-element-total-count",
-        keyword,
+        keyword: keywordInInput,
       });
 
       setTotalCount(response.totalCount);

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
-export function SearchSectionInput({ currentKeyword }) {
+export function SearchSectionInput({ currentKeyword, handleEnter, group }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(-1);
   const [value, setValue] = useState(currentKeyword);
   const [totalCount, setTotalCount] = useState(0);
@@ -48,6 +48,11 @@ export function SearchSectionInput({ currentKeyword }) {
         placeholder="키워드를 입력해 주세요"
         value={value}
         onChange={(event) => setValue(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && !group.includes(value)) {
+            handleEnter(value);
+          }
+        }}
       />
       <div className="buttonWrap absolute top-[75px] right-0 h-[50px] flex gap-[15px]">
         <span className="text-[#ccc] font-extralight leading-[50px]">
@@ -55,7 +60,10 @@ export function SearchSectionInput({ currentKeyword }) {
         </span>
         <button onClick={() => handleArrowClick("prev")}>↑</button>
         <button onClick={() => handleArrowClick("next")}>↓</button>
-        <button className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full">
+        <button
+          onClick={() => handleEnter(value)}
+          className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full"
+        >
           <img
             src="./search_icon.png"
             alt="search_icon"
@@ -69,4 +77,6 @@ export function SearchSectionInput({ currentKeyword }) {
 
 SearchSectionInput.propTypes = {
   currentKeyword: PropTypes.string.isRequired,
+  handleEnter: PropTypes.func.isRequired,
+  group: PropTypes.array.isRequired,
 };

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -1,9 +1,10 @@
 import PropTypes from "prop-types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function SearchSectionInput({ currentKeyword }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
   const [value, setValue] = useState(currentKeyword);
+  const [totalCount, setTotalCount] = useState(0);
 
   async function handleSearchClick() {
     const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
@@ -38,6 +39,24 @@ export function SearchSectionInput({ currentKeyword }) {
     }
   }
 
+  useEffect(() => {
+    async function getKeywordElementTotalCount(keyword) {
+      const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
+      const activeTab = tabs[0];
+      const response = await chrome.tabs.sendMessage(activeTab.id, {
+        message: "get-keyword-element-total-count",
+        keyword,
+      });
+
+      setTotalCount(response.totalCount);
+    }
+    getKeywordElementTotalCount(currentKeyword);
+
+  }, [currentKeyword]);
+
+  console.log("currentKeyword->", currentKeyword, "value->", value);
+  console.log("totalCount ->", totalCount)
+
   return (
     <>
       <input
@@ -49,7 +68,7 @@ export function SearchSectionInput({ currentKeyword }) {
       />
       <div className="buttonWrap absolute top-[75px] right-0 h-[50px] flex gap-[15px]">
         <span className="text-[#ccc] font-extralight leading-[50px]">
-          Total
+          {currentScrollIndex} / {totalCount}
         </span>
         <button onClick={() => handleArrowClick("prev")}>↑</button>
         <button onClick={() => handleArrowClick("next")}>↓</button>

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -2,23 +2,9 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
 export function SearchSectionInput({ currentKeyword }) {
-  const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
+  const [currentScrollIndex, setCurrentScrollIndex] = useState(-1);
   const [value, setValue] = useState(currentKeyword);
   const [totalCount, setTotalCount] = useState(0);
-
-  async function handleSearchClick() {
-    const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
-
-    const activeTab = tabs[0];
-    const response = await chrome.tabs.sendMessage(activeTab.id, {
-      init: true,
-      keyword: currentKeyword,
-    });
-
-    if (response.isDone) {
-      setCurrentScrollIndex(0);
-    }
-  }
 
   async function handleArrowClick(direction) {
     const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
@@ -31,17 +17,16 @@ export function SearchSectionInput({ currentKeyword }) {
     });
 
     if (response.isDone) {
-      if (direction === "next") {
-        setCurrentScrollIndex(currentScrollIndex + 1);
-      } else {
-        setCurrentScrollIndex(currentScrollIndex - 1);
-      }
+      setCurrentScrollIndex(response.newIndex);
     }
   }
 
   useEffect(() => {
     async function getKeywordElementTotalCount(keyword) {
-      const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
+      const tabs = await chrome.tabs.query({
+        currentWindow: true,
+        active: true,
+      });
       const activeTab = tabs[0];
       const response = await chrome.tabs.sendMessage(activeTab.id, {
         message: "get-keyword-element-total-count",
@@ -51,11 +36,7 @@ export function SearchSectionInput({ currentKeyword }) {
       setTotalCount(response.totalCount);
     }
     getKeywordElementTotalCount(currentKeyword);
-
   }, [currentKeyword]);
-
-  console.log("currentKeyword->", currentKeyword, "value->", value);
-  console.log("totalCount ->", totalCount)
 
   return (
     <>
@@ -72,10 +53,7 @@ export function SearchSectionInput({ currentKeyword }) {
         </span>
         <button onClick={() => handleArrowClick("prev")}>↑</button>
         <button onClick={() => handleArrowClick("next")}>↓</button>
-        <button
-          onClick={() => handleSearchClick()}
-          className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full"
-        >
+        <button className="bg-[#333] w-[70px] h-full flex justify-center items-center rounded-r-full">
           <img
             src="./search_icon.png"
             alt="search_icon"

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -38,6 +38,8 @@ export function SearchSectionInput({ currentKeyword }) {
     getKeywordElementTotalCount(currentKeyword);
   }, [currentKeyword]);
 
+  const indicator = `${currentScrollIndex}/${totalCount}`;
+
   return (
     <>
       <input
@@ -49,7 +51,7 @@ export function SearchSectionInput({ currentKeyword }) {
       />
       <div className="buttonWrap absolute top-[75px] right-0 h-[50px] flex gap-[15px]">
         <span className="text-[#ccc] font-extralight leading-[50px]">
-          {currentScrollIndex} / {totalCount}
+          {currentScrollIndex === -1 ? "" : indicator}
         </span>
         <button onClick={() => handleArrowClick("prev")}>↑</button>
         <button onClick={() => handleArrowClick("next")}>↓</button>

--- a/src/components/search-section/SearchSectionInput.jsx
+++ b/src/components/search-section/SearchSectionInput.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 export function SearchSectionInput({ currentKeyword }) {
   const [currentScrollIndex, setCurrentScrollIndex] = useState(0);
+  const [value, setValue] = useState(currentKeyword);
 
   async function handleSearchClick() {
     const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
@@ -43,6 +44,8 @@ export function SearchSectionInput({ currentKeyword }) {
         type="text"
         className="w-full h-[50px] border border-[100] pl-[20px] my-[30px] text-[#333] rounded-full"
         placeholder="키워드를 입력해 주세요"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
       />
       <div className="buttonWrap absolute top-[75px] right-0 h-[50px] flex gap-[15px]">
         <span className="text-[#ccc] font-extralight leading-[50px]">

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { convertToLinkMap } from "../../../background/convertToLinkMap";
 import TextButton from "../shared/TextButton";
@@ -34,9 +34,8 @@ export default function SearchSection() {
     return activeTab;
   }
 
-  async function handleKeywordClick() {
-    setIsKeywordOn(!isKeywordOn);
-    if (!isKeywordOn) {
+  useEffect(() => {
+    async function fireSearch() {
       const allInOneLinkMap = await collectAllLinkMap();
 
       const { url } = await getActiveTab();
@@ -49,9 +48,16 @@ export default function SearchSection() {
         const { keywords } = allInOneLinkMap.get(link);
         setCurrentKeyword(keywords[0]);
         setKeywordsForSearch([...keywords]);
+      } else {
+        setCurrentKeyword("");
+        setKeywordsForSearch([]);
       }
     }
-  }
+
+    if (isKeywordOn) {
+      fireSearch();
+    }
+  }, [isKeywordOn]);
 
   if (keywordsForSearch.length > 0) {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
@@ -70,7 +76,7 @@ export default function SearchSection() {
         <TextButton text={"Descrition"} />
         <TextButton
           text={"keyword"}
-          onClick={() => handleKeywordClick()}
+          onClick={() => setIsKeywordOn(!isKeywordOn)}
         />
       </div>
       <KeywordGroup

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -60,12 +60,16 @@ export default function SearchSection() {
     }
   }, [isKeywordOn]);
 
-  if (keywordsForSearch.length > 0) {
-    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      const activeTab = tabs[0];
-      chrome.tabs.sendMessage(activeTab.id, { keywords: keywordsForSearch });
-    });
-  }
+  useEffect(() => {
+    const group = [...bonus, ...keywordsForSearch];
+
+    if (group.length > 0) {
+      chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+        const activeTab = tabs[0];
+        chrome.tabs.sendMessage(activeTab.id, { keywords: group });
+      });
+    }
+  }, [bonus, keywordsForSearch]);
 
   return (
     <>

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -49,14 +49,14 @@ export default function SearchSection() {
         const { keywords } = allInOneLinkMap.get(link);
         setCurrentKeyword(keywords[0]);
         setKeywordsForSearch([...keywords]);
-      } else {
-        setCurrentKeyword("");
-        setKeywordsForSearch([]);
       }
     }
 
     if (isKeywordOn) {
       fireSearch();
+    } else {
+      setCurrentKeyword("");
+      setKeywordsForSearch([]);
     }
   }, [isKeywordOn]);
 
@@ -76,7 +76,10 @@ export default function SearchSection() {
       <SearchSectionInput
         key={currentKeyword}
         currentKeyword={currentKeyword}
-        handleEnter={(value) => setBonus((prv) => [value, ...prv])}
+        handleEnter={(value) => {
+          setBonus((prv) => [value, ...prv]);
+          setCurrentKeyword(value);
+        }}
         group={[...bonus, ...keywordsForSearch]}
       />
       <div className="flex gap-[15px]">

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from "react";
 
 import { convertToLinkMap } from "../../../background/convertToLinkMap";
 import TextButton from "../shared/TextButton";
-import { KeywordGroup } from "./KetwordGroup";
+import { KeywordGroup } from "./KeywordGroup";
 import { SearchSectionInput } from "./SearchSectionInput";
 
 export default function SearchSection() {
   const [isKeywordOn, setIsKeywordOn] = useState(false);
   const [keywordsForSearch, setKeywordsForSearch] = useState([]);
   const [currentKeyword, setCurrentKeyword] = useState("");
+  const [bonus, setBonus] = useState([]);
 
   async function collectAllLinkMap() {
     const tabIdToLinkMapJson = await chrome.storage.local.get(null);
@@ -71,6 +72,8 @@ export default function SearchSection() {
       <SearchSectionInput
         key={currentKeyword}
         currentKeyword={currentKeyword}
+        handleEnter={(value) => setBonus((prv) => [value, ...prv])}
+        group={[...bonus, ...keywordsForSearch]}
       />
       <div className="flex gap-[15px]">
         <TextButton text={"Descrition"} />
@@ -80,8 +83,8 @@ export default function SearchSection() {
         />
       </div>
       <KeywordGroup
-        currentKeyword={currentKeyword}
-        keywords={keywordsForSearch}
+        setCurrentKeyword={setCurrentKeyword}
+        group={[...bonus, ...keywordsForSearch]}
       />
     </>
   );


### PR DESCRIPTION
### 구현사진
![Jan-22-2025 21-19-39](https://github.com/user-attachments/assets/9d62f79e-9cb2-4fc8-9439-6f5644b80339)



### 작업 내용
-  사용자가 구글 검색 페이지에서 링크를 통해 이동한 페이지일 경우, 사용자가 keyword 버튼을 누르면 Input에 초기값으로 keyword가 제공됩니다.
- 사용자는 Input의 값을 수정할 수 있습니다.
- Input의 값을 수정하는 동안 Indicator는 보이지 않습니다.
- 수정 완료 후 사용자가 돋보기 버튼을 누를 경우 Input의 값은 Keyword Group에 추가되고, 한 페이지에 있는 전체 갯수가 Indicator로 표시됩니다.
- 동일한 값일 경우에는 추가되지 않습니다.
- 새롭게 추가된 값에 대해서도 페이지에 하이라이팅이 됩니다.
- 사용자가 위 또는 아래 방향의 화살표 버튼을 클릭시 순서에 맞춰 스크롤 되고, 현재 위치에 맞게 Indicator가 업데이트 됩니다.
- 사용자가 0이나 마지막 위치에 도달 시 동일한 화살표 버튼을 눌러도 위치와 Indicator는 업데이트 되지 않습니다.

### 기존 계획과 달라진 부분(+이유와 함께)
- 구글 검색 페이지에 있을 시 기본적으로 검색어가 하이라이팅 되도록 수정했습니다. 사용자가 하이라이팅 기능을 보다 직관적으로 이해하는 데 도움이 될 것이며 회의에서 결정된 사항입니다. 
- keyword하이라이팅 버튼을 클릭할 경우, description이 부분적으로 사라질 수 있습니다. 기존 기획에서는 링크를 타고 이동한 페이지에서, description과 keywords가 동시에 하이라이팅 되어 있는 모습으로 구상했었습니다. description의 문장 일치 정도가 정확한 것을 최우선 사항으로 보았고, 이를 위해서는 text-fragment 기능이 합리적이었습니다. 다만, text-fragment 기능을 사용할 경우 description과 keywords들이 동시에 하이라이팅 될 수는 없었습니다. 브라우저는 문서가 처음 렌더링 될 때만 text-fragment 글자를 칠해주고 그 이후에는 관심이 없습니다. 때문에 keywords를 하이라이팅 시키면서 DOM을 분해하고 조합하는 과정에서 description은 날아갈 수 밖에 없었습니다. 때문에 사용자에게 이후 선택권을 주는 방법으로 보완했습니다. 사용자는 keyword를 하이라이팅 시킬 수 있는 토글 버튼을 가질 수 있습니다. 사용자는 text-fragment로 색칠된 description이 아니라 keyword들을 보고 싶을 때 해당 버튼을 클릭할 수 있습니다.

### 차후 보완이 필요한 부분
- 하이라이팅 색상이 가독성에 좋지 않아 몇가지 배경색으로 어울리는 컬러칩을 도입해야 합니다. 

### 구현한 내용(체크박스로 나타내기)
- [X] 사이드패널 input 초기값은 여러 키워드 중 인덱스 0인 키워드
- [X] 동일한 키워드의 갯수를 표시
- [X] input에 값을 넣고 돋보기 버튼을 누르면, keyword group내부에 추가됨
- [X] input에 값을 넣고 엔터 시, keyword group내부에 추가됨
- [X] 동일한 값은 추가 불가
- [X] 추가와 동시에 하이라이트

### 리뷰어가 집중적으로 바줬으면 하는 것
- 위에서 아래로 코드를 읽었을 경우 대략적인 문맥이 이해가 되는 지 피드백을 얻고 싶십니다. 스크롤과 Input과 indicator와 keywordGroup간의 동기화과정에서 흐름이동이 잦았기 때문입니다.

### 관련 이슈
Closes #30 
