### PR TITLE
feat: lately history section 구현

### DIFF
--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -17,7 +17,7 @@ export default function HistorySection() {
   const groupTitle = "New Keyword Group";
   const favicon = "favicon";
   const siteName = "구글";
-  const url = "google.com";
+  const url = "https://www.google.com/";
   const keywords = { apple: 3, banana: 15 };
 
   function handleMovePage() {

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -14,7 +14,7 @@ export default function HistorySection() {
   const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
     new Date()
   );
-  const groupTitle = "New Keyword Group";
+  const groupId = "new-keyword-group";
   const favicon = "favicon";
   const siteName = "구글";
   const url = "https://www.google.com/";
@@ -45,7 +45,7 @@ export default function HistorySection() {
           addDefaultGroup(userToken);
           addHistory(
             userToken,
-            groupTitle,
+            groupId,
             favicon,
             siteName,
             url,

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { getHistories } from "../../firebase/CRUD";
+import HistoryItem from "../shared/HistoryItem";
 
 export default function LatelyHistoryGroup() {
   const [historyList, setHistoryList] = useState([]);
@@ -28,15 +29,12 @@ export default function LatelyHistoryGroup() {
       <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]">
         {historyList.map((history, index) => {
           return (
-            <li
+            <HistoryItem
               key={index}
-              className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full"
-            >
-              <a href={history.url}>
-                {history.faviconSrc}
-                {history.siteTitle}
-              </a>
-            </li>
+              url={history.url}
+              favicon={history.faviconSrc}
+              siteTitle={history.siteTitle}
+            />
           );
         })}
       </ul>

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -1,25 +1,44 @@
+import { useEffect, useState } from "react";
+
+import { getHistories } from "../../firebase/CRUD";
+
 export default function LatelyHistoryGroup() {
+  const [historyList, setHistoryList] = useState([]);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage(
+      {
+        message: "userStatus",
+      },
+      (response) => {
+        if (response.message) {
+          const userToken = response.message;
+          const groupId = "New Keyword Group";
+          getHistories(userToken, groupId, setHistoryList);
+        }
+      }
+    );
+  }, []);
+
   return (
     <div>
       <p className="text-lg font-semibold mt-[10px] mb-[10px]">
         lately History Group
       </p>
       <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]">
-        <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
-          <a href="#">
-            프론트엔드 3기 프로젝트 가이드 문서vanillacoding.craft.mev
-          </a>
-        </li>
-        <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
-          <a href="#">
-            2025년 개발자를 위한 최고의 Chrome 확장 프로그램 12가지
-          </a>
-        </li>
-        <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
-          <a href="#">
-            프론트엔드 3기 프로젝트 가이드 문서vanillacoding.craft.mev
-          </a>
-        </li>
+        {historyList.map((history, index) => {
+          return (
+            <li
+              key={index}
+              className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full"
+            >
+              <a href={history.url}>
+                {history.faviconSrc}
+                {history.siteTitle}
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -14,7 +14,7 @@ export default function LatelyHistoryGroup() {
       (response) => {
         if (response.message) {
           const userToken = response.message;
-          const groupId = "New Keyword Group";
+          const groupId = "new-keyword-group";
           getHistories(userToken, groupId, setHistoryList);
         }
       }

--- a/src/components/shared/HistoryItem.jsx
+++ b/src/components/shared/HistoryItem.jsx
@@ -1,0 +1,21 @@
+import PropTypes from "prop-types";
+
+export default function HistoryItem({ url, favicon, siteTitle }) {
+  function handleMoveUrl() {
+    chrome.tabs.create({ url: url });
+  }
+  return (
+    <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
+      <div onClick={handleMoveUrl}>
+        {favicon}
+        {siteTitle}
+      </div>
+    </li>
+  );
+}
+
+HistoryItem.propTypes = {
+  url: PropTypes.string.isRequired,
+  favicon: PropTypes.string.isRequired,
+  siteTitle: PropTypes.string.isRequired,
+};

--- a/src/firebase/CRUD.js
+++ b/src/firebase/CRUD.js
@@ -3,6 +3,7 @@ import {
   deleteDoc,
   doc,
   getDocs,
+  limit,
   query,
   setDoc,
 } from "firebase/firestore";
@@ -55,7 +56,10 @@ async function getGroups(token, callback) {
 }
 
 async function getHistories(token, groupId, callback) {
-  const histories = query(collection(db, token, groupId, "histories"));
+  const histories = query(
+    collection(db, token, groupId, "histories"),
+    limit(10)
+  );
   const historyList = await getDocs(histories);
   historyList.forEach((history) => {
     const historyData = {

--- a/src/firebase/CRUD.js
+++ b/src/firebase/CRUD.js
@@ -11,7 +11,7 @@ import {
 import { db } from "./firebase";
 
 async function addDefaultGroup(token) {
-  const rootCollection = doc(db, token, "New Keyword Group");
+  const rootCollection = doc(db, token, "new-keyword-group");
   await setDoc(rootCollection, {
     title: "New Keyword Group",
   });


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/95f8d865-f56a-4a45-8241-f57753718930
### 작업 내용
- 사용자가 저장한 history list를 하나의 section에서 최대 10개까지 노출
### 차후 보완이 필요한 부분
- 실제 데이터를 이용하여 에러가 발생하는지 확인 필요
- history추가 버튼을 눌렀을 때, 바로 lately history section에 보일 수 있게 기능을 추가
### 구현한 내용(체크박스로 나타내기)
- [X] 최근 등록순으로 최대 10개까지만 노출
- [X] 간결하게 사이트 이름만 표시함
- [X] 클릭 시 해당 url로 이동하는 기능
### 리뷰어가 집중적으로 바줬으면 하는 것
- mock data를 이용한 작업이라 파비콘과 사이트 이름은 임시적입니다.
- 파비콘과 사이트 이름은 놓인 위치만 봐주시기 바랍니다.
- 파비콘과 사이트 이름 외에 노출시키고 싶은 data가 있으시다면 말씀주시기 바랍니다.
### 관련 이슈
feat: lately history section 구현 #35
