### PR TITLE
fix: history 저장 관련 mock data에서 real data로 변경

### DIFF
--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -4,24 +4,6 @@ import { addDefaultGroup, addHistory } from "../../firebase/CRUD";
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection({ countsPerKeywords }) {
-  let userToken = "";
-  const options = {
-    year: "numeric",
-    month: "numeric",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-  };
-  const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
-    new Date()
-  );
-  const groupId = "new-keyword-group";
-  const favicon = "favicon";
-  const siteName = "구글";
-  const url = "https://www.google.com/";
-  const keywords = { apple: 3, banana: 15 };
-
   function handleMovePage() {
     chrome.runtime.sendMessage(
       {
@@ -29,7 +11,6 @@ export default function HistorySection({ countsPerKeywords }) {
       },
       (response) => {
         if (response.message) {
-          userToken = response.message;
           chrome.tabs.create({ url: "http://localhost:5174" });
         }
       }
@@ -37,8 +18,18 @@ export default function HistorySection({ countsPerKeywords }) {
   }
 
   async function handleAddHistory(countsPerKeywords) {
-    // eslint-disable-next-line no-unused-vars
     const history = await getHistoryData(countsPerKeywords);
+    const groupId = "new-keyword-group";
+    const options = {
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    };
+    const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
+      new Date(history.createdTime)
+    );
+    const favicon = history.faviconSrc ? history.faviconSrc : "";
 
     chrome.runtime.sendMessage(
       {
@@ -46,16 +37,16 @@ export default function HistorySection({ countsPerKeywords }) {
       },
       (response) => {
         if (response.message) {
-          userToken = response.message;
+          const userToken = response.message;
           addDefaultGroup(userToken);
           addHistory(
             userToken,
             groupId,
             favicon,
-            siteName,
-            url,
+            history.siteTitle,
+            history.url,
             currentDate,
-            keywords
+            history.keywords
           );
         }
       }

--- a/src/components/shared/HistoryItem.jsx
+++ b/src/components/shared/HistoryItem.jsx
@@ -6,8 +6,13 @@ export default function HistoryItem({ url, favicon, siteTitle }) {
   }
   return (
     <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
-      <div onClick={handleMoveUrl}>
-        {favicon}
+      <div
+        onClick={handleMoveUrl}
+        className="flex gap-[10px] justify-start items-center"
+      >
+        <div className="w-[20px] h-[20px] object-fill rounded-full">
+          <img src={favicon} />
+        </div>
         {siteTitle}
       </div>
     </li>


### PR DESCRIPTION
### 구현사진
<img width="532" alt="image" src="https://github.com/user-attachments/assets/2c86a8a5-7076-4aa1-84a9-7a5dad4c0667" />

![image](https://github.com/user-attachments/assets/27634f09-f5de-44ef-bc0f-2bbe8ea56d02)

### 작업 내용
- history section에 있는 history저장을 mock data가 아닌 real data로 변경
- lately history section favicon 노출 문제 해결
### 구현한 내용(체크박스로 나타내기)
- [X] real data를 반환하는 함수 적용
- [X] 기능 측면 오류 발생 여부 확인
- [X] favicon issue
### 관련 이슈
fix: history 저장 관련 mock data에서 real data로 변경 #42
