### PR TITLE
feat: firestore연동을 위해 user 스키마 설정 후 history 추가 기능

### DIFF
--- a/src/firebase/history.js
+++ b/src/firebase/history.js
@@ -1,0 +1,26 @@
+import { addDoc, collection } from "firebase/firestore";
+
+import { db } from "./firebase";
+
+export async function addHistoryToDefaultGroup(userId, history) {
+  const historiesRef = collection(
+    db,
+    "users",
+    userId,
+    "groups",
+    "default",
+    "histories"
+  );
+
+  const historyForDB = {
+    faviconSrc: history.faviconSrc ? history.faviconSrc : "",
+    siteTitle: history.siteTitle,
+    url: history.url,
+    createdTime: history.createdTime,
+    keywords: history.keywords,
+  };
+
+  const historyDocRef = await addDoc(historiesRef, historyForDB);
+
+  return historyDocRef.id;
+}

--- a/src/firebase/user.js
+++ b/src/firebase/user.js
@@ -1,0 +1,41 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  query,
+  setDoc,
+  where,
+} from "firebase/firestore";
+
+import { db } from "./firebase";
+
+export async function addNewUserAndDefaultGroup(email) {
+  const userDocRef = await addDoc(collection(db, "users"), {
+    email: email,
+  });
+
+  const groupsRef = collection(db, "users", userDocRef.id, "groups");
+
+  await setDoc(doc(groupsRef, "default"), {
+    name: "New Keyword Group",
+  });
+
+  return userDocRef.id;
+}
+
+export async function getUser(email) {
+  const usersRef = collection(db, "users");
+  const q = query(usersRef, where("email", "==", email));
+
+  const querySnapshot = await getDocs(q);
+  const arr = [];
+  if (querySnapshot.empty) {
+    return null;
+  } else {
+    querySnapshot.forEach((user) => {
+      arr.push(user.id);
+    });
+    return arr[0];
+  }
+}

--- a/src/firebase/user.js
+++ b/src/firebase/user.js
@@ -29,13 +29,13 @@ export async function getUser(email) {
   const q = query(usersRef, where("email", "==", email));
 
   const querySnapshot = await getDocs(q);
-  const arr = [];
+  const userIdList = [];
   if (querySnapshot.empty) {
     return null;
   } else {
     querySnapshot.forEach((user) => {
-      arr.push(user.id);
+      userIdList.push(user.id);
     });
-    return arr[0];
+    return userIdList[0];
   }
 }


### PR DESCRIPTION
### 작업 내용
- getUser를 email과 함께 호출하게 되면, 사용자가 DB에 존재하는 지 여부를 알 수 있습니다. 
  - 존재할 경우 userId를 얻을 수 있습니다.
  - 존재하지 않을 경우 null이 반환됩니다.
- 존재하지 않을 경우 email과 함께 addNewUserAndDefaultGroup를 호출하게 되면, 다음과 같은 작업이 시작됩니다.
  - 새로운 사용자를 DB에 생성합니다.
  - 생성된 사용자에게 default group이 주어집니다.
  - 반환값으로 userId를 얻을 수 있습니다.
- addHistoryToDefaultGroup을 호출해 사용자의 default group안에 history를 저장할 수 있습니다.
  - 사용자 식별을 위해 userId와, history를 만드는 데 필요한 데이터의 제공이 필요합니다.
  - 새롭게 생성된 history의 id를 반환받을 수 있습니다.

### 차후 보완이 필요한 부분
- 해당 함수들을 호출하는 상황이 현재와 달라질 수 있어 상황에 맞춰 빠른 보완작업이 진행될 예정입니다.
- 예외 상황 대응

### 구현한 내용(체크박스로 나타내기)
- [X] 현재 email을 가지고 있는 사용자가 DB에 존재하는 지 여부를 알려주는 함수
- [X] 새로운 사용자일 경우, 새 사용자를 DB에 추가하고 (비어있는) default group을 가지게 하는 함수
- [X] 사용자가 history 저장 버튼을 클릭할 시, 위의 default group에 history를 추가하는 함수

### 리뷰어가 집중적으로 바줬으면 하는 것
- 위에서 아래로 읽었을 경우 가독성
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #45 