### PR TITLE
feat: webSite auth Data + extension auth Data 연동 기능

### DIFF
--- a/content-script/content.js
+++ b/content-script/content.js
@@ -108,3 +108,9 @@ function scroll(step, currentScrollIndex, keyword) {
 
   return { isDone: true, newIndex: currentScrollIndex + step };
 }
+
+const userEmail = localStorage.getItem("userEmail");
+chrome.runtime.sendMessage({
+  message: "success",
+  data: userEmail,
+});

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -110,7 +110,6 @@ function scroll(step, currentScrollIndex, keyword) {
 }
 
 const userEmail = localStorage.getItem("userEmail");
-chrome.runtime.sendMessage({
-  message: "success",
-  data: userEmail,
-});
+
+userEmail &&
+  chrome.runtime.sendMessage({ message: "success", data: userEmail });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -21,7 +21,7 @@
     }
   ],
   "oauth2": {
-    "client_id": "399990500021-ph0q3br6s9io670u9vt0sotshsk5fafq.apps.googleusercontent.com",
+    "client_id": "399990500021-6u6jceebjt0hmvcmmlbvfrm3iakq7ef1.apps.googleusercontent.com",
     "scopes": [
       "https://www.googleapis.com/auth/userinfo.profile",
       "https://www.googleapis.com/auth/userinfo.email"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,13 @@ const queryClient = new QueryClient();
 function App() {
   const [countsPerKeywords, setCountsPerKeywords] = useState([]);
 
+  chrome.runtime.onMessage.addListener((request) => {
+    if (request.message === "success") {
+      localStorage.setItem("userEmail", request.data);
+    }
+    return true;
+  });
+
   return (
     <QueryClientProvider client={queryClient}>
       <HistorySection countsPerKeywords={countsPerKeywords} />

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -11,7 +11,7 @@ export default function HistorySection({ countsPerKeywords }) {
       },
       (response) => {
         if (response.message) {
-          chrome.tabs.create({ url: "http://localhost:5174" });
+          chrome.tabs.create({ url: "http://localhost:5173" });
         }
       }
     );


### PR DESCRIPTION
### 구현사진
**UserEmail**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e09bfeee-bae7-4699-896b-713b43d73309" />

**Local Storage Value**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f3cf4158-ae17-47bc-bd82-9e7159334636" />

### 작업 내용
- 사용자가 로그인 진행 시 사용자의 이메일값을 local Storage로 받아와 식별 진행하는 로직을 구현하였습니다. 

## 기존 계획과 달라진 부분(+이유와 함께)
- 구글 로그인 연동하여 사용자 식별을 진행하려던 로직 → 로컬 스토리지에 사용자의 이메일의 정보의 식별로 인해 로그인 유무를 판단
- 사유 : extension 구글 로그인 진행 시 localStorage에 사용자 식별이 불분명하고 값이 담기지않는 상황으로 인해 wegSite 로그인으로 변경해서 진행하기로 한 사유로 인해 변경되었습니다.

### 차후 보완이 필요한 부분
- 사용자의 이메일 값을 식별하여 로그인을 안할경우 localhost:5173/login 페이지로 이동해야합니다.
- 사용자의 이메일 값을 이미 보유하고 있는 상황이라면 기존 history웹 페이지로 이동해야합니다.
 
### 구현한 내용(체크박스로 나타내기)
- 사용자자 식별을 위해 웹사이트에서 가져온 사용자의 이메일 정보 + 사용자 accesstoken 정보와 extension이 연동되어야한다.

### 리뷰어가 집중적으로 바줬으면 하는 것
- extension에서 주로 다루는 Script 및 확인해야하는 Dev tool들이 기존의 webSite와 다르게 다수인지라 로직 파악하는데 시간이 오래 걸린 사유가 있습니다.  너그러히 기다려주셔서 정말 감사합니다. 코드 보시면서 혹시 이해 안 가시는 부분이 있으시면 가감없이 편히 의견 부탁드립니다(_ _)
 
- 해당 2개의 파일은 localhost port 번호 변경 및 로그인 진행 시 client_id 변경을 위해 진행된 파일이라 ignore해 주셔도 됩니다. 
    - public/manifest.json
    - src/components/history-section/index.jsx
    
### 관련 이슈
- feat: webSite auth Data + extension auth Data 연동 기능 #47 
