### PR TITLE
feat: webSite + extension auth identification 후 로그인 페이지 이동

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -13,15 +13,6 @@ chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.message === "userStatus") {
-    chrome.identity.getAuthToken({ interactive: true }, function (token) {
-      sendResponse({ message: token });
-    });
-  }
-  return true;
-});
-
 chrome.webNavigation.onCompleted.addListener((details) => {
   const url = new URL(details.url);
   const isGoogleSearch =

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -110,6 +110,12 @@ function scroll(step, currentScrollIndex, keyword) {
 }
 
 const userEmail = localStorage.getItem("userEmail");
+const userAccessToken = localStorage.getItem("userAccessToken");
 
 userEmail &&
-  chrome.runtime.sendMessage({ message: "success", data: userEmail });
+  userAccessToken &&
+  chrome.runtime.sendMessage({
+    message: "success",
+    emailData: userEmail,
+    tokenData: userAccessToken,
+  });

--- a/content-script/content.js
+++ b/content-script/content.js
@@ -115,7 +115,7 @@ const userAccessToken = localStorage.getItem("userAccessToken");
 userEmail &&
   userAccessToken &&
   chrome.runtime.sendMessage({
-    message: "success",
+    message: "Get user authentication",
     emailData: userEmail,
     tokenData: userAccessToken,
   });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -37,7 +37,6 @@
     "notifications",
     "declarativeNetRequest",
     "declarativeNetRequestFeedback",
-    "identity",
     "tabs"
   ],
   "host_permissions": ["<all_urls>"],

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import HistorySection from "./components/history-section";
 import LatelyHistoryGroup from "./components/lately-history-croup/LatelyHistoryGroup";
 import SearchSection from "./components/search-section";
+import UserInfoProvider from "./context/UserInfo";
 
 const queryClient = new QueryClient();
 
@@ -11,7 +12,7 @@ function App() {
   const [countsPerKeywords, setCountsPerKeywords] = useState([]);
 
   chrome.runtime.onMessage.addListener((request) => {
-    if (request.message === "success") {
+    if (request.message === "Get user authentication") {
       localStorage.setItem("userEmail", request.emailData);
       localStorage.setItem("userAccessToken", request.tokenData);
     }
@@ -19,14 +20,16 @@ function App() {
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <HistorySection countsPerKeywords={countsPerKeywords} />
-      <SearchSection
-        countsPerKeywords={countsPerKeywords}
-        setCountsPerKeywords={setCountsPerKeywords}
-      />
-      <LatelyHistoryGroup />
-    </QueryClientProvider>
+    <UserInfoProvider>
+      <QueryClientProvider client={queryClient}>
+        <HistorySection countsPerKeywords={countsPerKeywords} />
+        <SearchSection
+          countsPerKeywords={countsPerKeywords}
+          setCountsPerKeywords={setCountsPerKeywords}
+        />
+        <LatelyHistoryGroup />
+      </QueryClientProvider>
+    </UserInfoProvider>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,8 @@ function App() {
 
   chrome.runtime.onMessage.addListener((request) => {
     if (request.message === "success") {
-      localStorage.setItem("userEmail", request.data);
+      localStorage.setItem("userEmail", request.emailData);
+      localStorage.setItem("userAccessToken", request.tokenData);
     }
     return true;
   });

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -5,16 +5,14 @@ import IconButton from "../shared/IconButton";
 
 export default function HistorySection({ countsPerKeywords }) {
   function handleMovePage() {
-    chrome.runtime.sendMessage(
-      {
-        message: "userStatus",
-      },
-      (response) => {
-        if (response.message) {
-          chrome.tabs.create({ url: "http://localhost:5173" });
-        }
-      }
-    );
+    const userEmail = localStorage.getItem("userEmail");
+    const userAccessToken = localStorage.getItem("userAccessToken");
+
+    if (userEmail && userAccessToken) {
+      chrome.tabs.create({ url: "http://localhost:5173" });
+    } else {
+      chrome.tabs.create({ url: "http://localhost:5173/login" });
+    }
   }
 
   async function handleAddHistory(countsPerKeywords) {

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -1,12 +1,17 @@
 import PropTypes from "prop-types";
 
+import { useUserInfo } from "../../context/UserInfo";
 import { addDefaultGroup, addHistory } from "../../firebase/CRUD";
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection({ countsPerKeywords }) {
+  const { setUserInfo } = useUserInfo();
+
   function handleMovePage() {
     const userEmail = localStorage.getItem("userEmail");
     const userAccessToken = localStorage.getItem("userAccessToken");
+
+    setUserInfo([userEmail, userAccessToken]);
 
     if (userEmail && userAccessToken) {
       chrome.tabs.create({ url: "http://localhost:5173" });

--- a/src/context/UserInfo.jsx
+++ b/src/context/UserInfo.jsx
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+import { createContext, useContext, useState } from "react";
+
+const UserInfoContext = createContext(null);
+
+export default function UserInfoProvider({ children }) {
+  const [userInfo, setUserInfo] = useState(() => {
+    const userEmail = localStorage.getItem("userEmail");
+    const userAccessToken = localStorage.getItem("userAccessToken");
+    const userInfo = [userEmail, userAccessToken];
+
+    return userInfo;
+  });
+
+  return (
+    <UserInfoContext.Provider value={{ userInfo, setUserInfo }}>
+      {children}
+    </UserInfoContext.Provider>
+  );
+}
+
+export const useUserInfo = () => useContext(UserInfoContext);
+
+UserInfoProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+};


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/38e7b626-a15e-4ba9-9d68-100976916b4c

### 작업 내용
- 사용자의 로그인 정보가 있을 경우에는 History 페이지로 이동됩니다.
- 사용자의 로그인 정보가 없을 경우에는 localhost:5173/login 페이지로 이동됩니다.

### 차후 보완이 필요한 부분
- 사용자가 로그인 완료 후 로그인 정보가 있을 경우 History 페이지로 redirect시키는 부분을 보완하여야 합니다. 

### 구현한 내용(체크박스로 나타내기)
- [x] 확장프로그램 실행 → 히스토리페이지 클릭 → 로그인 식별 완료 → 히스토리페이지 진입
- [x] 확장프로그램 실행 → 히스토리페이지 클릭 → 로그인 식별 불가 → 로그인 페이지 localhost:5173/login

### 리뷰어가 집중적으로 바줬으면 하는 것
- 현재 local storage에서 userEmail과 userAccessToken을 필요할 때마다 갖고 오는 로직인데 별도 상태관리가 필요할지 고민이 되었던 부분이라 같이 고민해 주시면서 봐주시면 감사드리겠습니다!

### 관련 이슈
- feat: webSite + extension auth identification 후 로그인 페이지 이동 #48 