### PR TITLE
fix: 하이라이트 토글 동기화

### DIFF
--- a/content-script/content.js
+++ b/content-script/content.js
@@ -57,7 +57,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.message === "toggle-highlight") {
-    if (request.toggleIsOn) {
+    if (request.isHighlightOn) {
       applyHighlight(request.targetKeyword, makeRandomBackgroundColor());
     } else {
       turnOffHighlight(request.targetKeyword);
@@ -67,7 +67,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.message === "toggle-highlight-all") {
-    if (request.toggleIsOn) {
+    if (request.isHighlightOn) {
       applyHighlightAll(request.targetKeywords);
     } else {
       turnOffHighlightAll();

--- a/src/components/search-section/KeywordGroup.jsx
+++ b/src/components/search-section/KeywordGroup.jsx
@@ -2,9 +2,7 @@ import PropTypes from "prop-types";
 
 import { ToggleableKeywordButton } from "./ToggleableKeywordButton";
 
-export function KeywordGroup({ countsPerKeywords, handleDelete }) {
-  const existingKeywords = countsPerKeywords.map(({ keyword }) => keyword);
-
+export function KeywordGroup({ toggleStatus, setToggleStatus, handleDelete }) {
   return (
     <>
       <div>
@@ -12,13 +10,28 @@ export function KeywordGroup({ countsPerKeywords, handleDelete }) {
           Keyword Group
         </p>
         <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-center grid grid-cols-3 gap-[15px] px-[10px] py-[20px]">
-          {existingKeywords.map((keyword) => {
+          {toggleStatus.map(({ keyword, isOn }) => {
+            function toggleIsOn(targetKeyword) {
+              setToggleStatus((prev) =>
+                prev.map(({ keyword, isOn }) => {
+                  if (keyword === targetKeyword) {
+                    return { keyword, isOn: !isOn };
+                  }
+                  return { keyword, isOn };
+                })
+              );
+            }
+
             return (
               <li
                 key={keyword}
                 className="text-xs py-[10px]"
               >
-                <ToggleableKeywordButton keyword={keyword} />
+                <ToggleableKeywordButton
+                  keyword={keyword}
+                  isOn={isOn}
+                  toggleKeywordIsOn={() => toggleIsOn(keyword)}
+                />
                 <button
                   onClick={() => handleDelete(keyword)}
                   className="px-1"
@@ -35,6 +48,7 @@ export function KeywordGroup({ countsPerKeywords, handleDelete }) {
 }
 
 KeywordGroup.propTypes = {
-  countsPerKeywords: PropTypes.array.isRequired,
+  toggleStatus: PropTypes.array.isRequired,
+  setToggleStatus: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
 };

--- a/src/components/search-section/KeywordGroup.jsx
+++ b/src/components/search-section/KeywordGroup.jsx
@@ -3,6 +3,17 @@ import PropTypes from "prop-types";
 import { ToggleableKeywordButton } from "./ToggleableKeywordButton";
 
 export function KeywordGroup({ toggleStatus, setToggleStatus, handleDelete }) {
+  function toggleIsOn(targetKeyword) {
+    const nextStatus = toggleStatus.map(({ keyword, isOn }) => {
+      if (keyword === targetKeyword) {
+        return { keyword, isOn: !isOn };
+      }
+      return { keyword, isOn };
+    });
+
+    setToggleStatus(nextStatus);
+  }
+
   return (
     <>
       <div>
@@ -11,17 +22,6 @@ export function KeywordGroup({ toggleStatus, setToggleStatus, handleDelete }) {
         </p>
         <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-center grid grid-cols-3 gap-[15px] px-[10px] py-[20px]">
           {toggleStatus.map(({ keyword, isOn }) => {
-            function toggleIsOn(targetKeyword) {
-              setToggleStatus((prev) =>
-                prev.map(({ keyword, isOn }) => {
-                  if (keyword === targetKeyword) {
-                    return { keyword, isOn: !isOn };
-                  }
-                  return { keyword, isOn };
-                })
-              );
-            }
-
             return (
               <li
                 key={keyword}

--- a/src/components/search-section/KeywordGroup.jsx
+++ b/src/components/search-section/KeywordGroup.jsx
@@ -18,10 +18,7 @@ export function KeywordGroup({ countsPerKeywords, handleDelete }) {
                 key={keyword}
                 className="text-xs py-[10px]"
               >
-                <ToggleableKeywordButton
-                  isAll={false}
-                  keyword={keyword}
-                />
+                <ToggleableKeywordButton keyword={keyword} />
                 <button
                   onClick={() => handleDelete(keyword)}
                   className="px-1"

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -3,10 +3,10 @@ import { useState } from "react";
 
 import { ToggleableTextButton } from "../shared/TextButton";
 
-export function ToggleableKeywordButton({ keyword }) {
+export function ToggleableAllKeywordsButton({ countsPerKeywords }) {
   const [isOn, setIsOn] = useState(true);
 
-  async function handleClick(isOn) {
+  async function handleClickAll(isOn) {
     const nextIsOn = !isOn;
 
     setIsOn(nextIsOn);
@@ -17,21 +17,21 @@ export function ToggleableKeywordButton({ keyword }) {
     });
     const activeTab = tabs[0];
     await chrome.tabs.sendMessage(activeTab.id, {
-      message: "toggle-highlight",
+      message: "toggle-highlight-all",
       toggleIsOn: nextIsOn,
-      targetKeyword: keyword,
+      targetKeywords: countsPerKeywords.map(({ keyword }) => keyword),
     });
   }
 
   return (
     <ToggleableTextButton
-      onClick={() => handleClick(isOn)}
-      text={keyword}
+      onClick={() => handleClickAll(isOn)}
+      text={"Highlight All Keywords"}
       isOn={isOn}
     />
   );
 }
 
-ToggleableKeywordButton.propTypes = {
-  keyword: PropTypes.string,
+ToggleableAllKeywordsButton.propTypes = {
+  countsPerKeywords: PropTypes.array,
 };

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -3,13 +3,17 @@ import { useState } from "react";
 
 import { ToggleableTextButton } from "../shared/TextButton";
 
-export function ToggleableAllKeywordsButton({ countsPerKeywords }) {
+export function ToggleableAllKeywordsButton({
+  countsPerKeywords,
+  toggleAllKeywordsIsOn,
+}) {
   const [isOn, setIsOn] = useState(true);
 
   async function handleClickAll(isOn) {
     const nextIsOn = !isOn;
 
     setIsOn(nextIsOn);
+    toggleAllKeywordsIsOn();
 
     const tabs = await chrome.tabs.query({
       currentWindow: true,
@@ -34,4 +38,5 @@ export function ToggleableAllKeywordsButton({ countsPerKeywords }) {
 
 ToggleableAllKeywordsButton.propTypes = {
   countsPerKeywords: PropTypes.array,
+  toggleAllKeywordsIsOn: PropTypes.func.isRequired,
 };

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -9,6 +9,15 @@ export function ToggleableAllKeywordsButton({
 }) {
   const [isOn, setIsOn] = useState(true);
 
+  const onCount = toggleStatus.filter(({ isOn }) => isOn === true).length;
+  const offCount = toggleStatus.filter(({ isOn }) => isOn === false).length;
+
+  const wouldChange = (isOn && onCount === 0) || (!isOn && offCount === 0);
+
+  if (toggleStatus.length !== 0 && wouldChange) {
+    setIsOn(!isOn);
+  }
+
   async function handleClickAll(isOn) {
     const nextIsOn = !isOn;
 

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -22,7 +22,7 @@ export function ToggleableAllKeywordsButton({
     const activeTab = tabs[0];
     await chrome.tabs.sendMessage(activeTab.id, {
       message: "toggle-highlight-all",
-      toggleIsOn: nextIsOn,
+      isHighlightOn: nextIsOn,
       targetKeywords: toggleStatus.map(({ keyword }) => keyword),
     });
   }

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -13,7 +13,7 @@ export function ToggleableAllKeywordsButton({
     const nextIsOn = !isOn;
 
     setIsOn(nextIsOn);
-    toggleAllKeywordsIsOn();
+    toggleAllKeywordsIsOn(nextIsOn);
 
     const tabs = await chrome.tabs.query({
       currentWindow: true,

--- a/src/components/search-section/ToggleableAllKeywordsButton.jsx
+++ b/src/components/search-section/ToggleableAllKeywordsButton.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { ToggleableTextButton } from "../shared/TextButton";
 
 export function ToggleableAllKeywordsButton({
-  countsPerKeywords,
+  toggleStatus,
   toggleAllKeywordsIsOn,
 }) {
   const [isOn, setIsOn] = useState(true);
@@ -23,7 +23,7 @@ export function ToggleableAllKeywordsButton({
     await chrome.tabs.sendMessage(activeTab.id, {
       message: "toggle-highlight-all",
       toggleIsOn: nextIsOn,
-      targetKeywords: countsPerKeywords.map(({ keyword }) => keyword),
+      targetKeywords: toggleStatus.map(({ keyword }) => keyword),
     });
   }
 
@@ -37,6 +37,6 @@ export function ToggleableAllKeywordsButton({
 }
 
 ToggleableAllKeywordsButton.propTypes = {
-  countsPerKeywords: PropTypes.array,
+  toggleStatus: PropTypes.array.isRequired,
   toggleAllKeywordsIsOn: PropTypes.func.isRequired,
 };

--- a/src/components/search-section/ToggleableKeywordButton.jsx
+++ b/src/components/search-section/ToggleableKeywordButton.jsx
@@ -15,7 +15,7 @@ export function ToggleableKeywordButton({ keyword, isOn, toggleKeywordIsOn }) {
     const activeTab = tabs[0];
     await chrome.tabs.sendMessage(activeTab.id, {
       message: "toggle-highlight",
-      toggleIsOn: nextIsOn,
+      isHighlightOn: nextIsOn,
       targetKeyword: keyword,
     });
   }

--- a/src/components/search-section/ToggleableKeywordButton.jsx
+++ b/src/components/search-section/ToggleableKeywordButton.jsx
@@ -1,15 +1,12 @@
 import PropTypes from "prop-types";
-import { useState } from "react";
 
 import { ToggleableTextButton } from "../shared/TextButton";
 
-export function ToggleableKeywordButton({ keyword }) {
-  const [isOn, setIsOn] = useState(true);
-
+export function ToggleableKeywordButton({ keyword, isOn, toggleKeywordIsOn }) {
   async function handleClick(isOn) {
     const nextIsOn = !isOn;
 
-    setIsOn(nextIsOn);
+    toggleKeywordIsOn();
 
     const tabs = await chrome.tabs.query({
       currentWindow: true,
@@ -34,4 +31,6 @@ export function ToggleableKeywordButton({ keyword }) {
 
 ToggleableKeywordButton.propTypes = {
   keyword: PropTypes.string,
+  isOn: PropTypes.bool.isRequired,
+  toggleKeywordIsOn: PropTypes.func.isRequired,
 };

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -131,7 +131,7 @@ export default function SearchSection({
           onClick={() => handleKeywordTextButtonClick(isKeywordOn)}
         />
         <ToggleableAllKeywordsButton
-          countsPerKeywords={countsPerKeywords}
+          toggleStatus={toggleStatus}
           toggleAllKeywordsIsOn={toggleAllKeywordsIsOn}
         />
       </div>

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -14,6 +14,7 @@ export default function SearchSection({
   const [isKeywordOn, setIsKeywordOn] = useState(false);
   const [keywordsForSearch, setKeywordsForSearch] = useState([]);
   const [bonus, setBonus] = useState([]);
+  const [toggleStatus, setToggleStatus] = useState([]);
 
   async function collectAllLinkMap() {
     const tabIdToLinkMapJson = await chrome.storage.local.get(null);
@@ -52,6 +53,17 @@ export default function SearchSection({
         });
 
         setCountsPerKeywords(response);
+        setToggleStatus((prev) => {
+          const prevKeywords = prev.map(({ keyword }) => keyword);
+          const newKeywords = response
+            .map(({ keyword }) => keyword)
+            .filter((keyword) => !prevKeywords.includes(keyword));
+          const newToggleStatus = newKeywords.map((keyword) => ({
+            keyword,
+            isOn: true,
+          }));
+          return [...prev, ...newToggleStatus];
+        });
       }
     }
 
@@ -92,6 +104,12 @@ export default function SearchSection({
     setKeywordsForSearch((prev) => prev.filter((k) => k !== keyword));
   }
 
+  function toggleAllKeywordsIsOn() {
+    setToggleStatus((prev) =>
+      prev.map(({ keyword, isOn }) => ({ keyword, isOn: !isOn }))
+    );
+  }
+
   return (
     <>
       <SearchSectionInput
@@ -106,10 +124,14 @@ export default function SearchSection({
           text={"Start Searcher"}
           onClick={() => handleKeywordTextButtonClick(isKeywordOn)}
         />
-        <ToggleableAllKeywordsButton countsPerKeywords={countsPerKeywords} />
+        <ToggleableAllKeywordsButton
+          countsPerKeywords={countsPerKeywords}
+          toggleAllKeywordsIsOn={toggleAllKeywordsIsOn}
+        />
       </div>
       <KeywordGroup
-        countsPerKeywords={countsPerKeywords}
+        toggleStatus={toggleStatus}
+        setToggleStatus={setToggleStatus}
         handleDelete={handleKeywordDelete}
       />
     </>

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -110,9 +110,9 @@ export default function SearchSection({
     setKeywordsForSearch((prev) => prev.filter((k) => k !== keyword));
   }
 
-  function toggleAllKeywordsIsOn() {
+  function toggleAllKeywordsIsOn(nextIsOn) {
     setToggleStatus((prev) =>
-      prev.map(({ keyword, isOn }) => ({ keyword, isOn: !isOn }))
+      prev.map(({ keyword }) => ({ keyword, isOn: nextIsOn }))
     );
   }
 

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -5,7 +5,7 @@ import { convertToLinkMap } from "../../../background/convertToLinkMap";
 import TextButton from "../shared/TextButton";
 import { KeywordGroup } from "./KeywordGroup";
 import { SearchSectionInput } from "./SearchSectionInput";
-import { ToggleableKeywordButton } from "./ToggleableKeywordButton";
+import { ToggleableAllKeywordsButton } from "./ToggleableAllKeywordsButton";
 
 export default function SearchSection({
   countsPerKeywords,
@@ -106,10 +106,7 @@ export default function SearchSection({
           text={"Start Searcher"}
           onClick={() => handleKeywordTextButtonClick(isKeywordOn)}
         />
-        <ToggleableKeywordButton
-          isAll={true}
-          countsPerKeywords={countsPerKeywords}
-        />
+        <ToggleableAllKeywordsButton countsPerKeywords={countsPerKeywords} />
       </div>
       <KeywordGroup
         countsPerKeywords={countsPerKeywords}

--- a/src/components/search-section/index.jsx
+++ b/src/components/search-section/index.jsx
@@ -54,15 +54,21 @@ export default function SearchSection({
 
         setCountsPerKeywords(response);
         setToggleStatus((prev) => {
+          const currentKeywords = response.map(({ keyword }) => keyword);
           const prevKeywords = prev.map(({ keyword }) => keyword);
-          const newKeywords = response
-            .map(({ keyword }) => keyword)
-            .filter((keyword) => !prevKeywords.includes(keyword));
+
+          const newKeywords = currentKeywords.filter(
+            (keyword) => !prevKeywords.includes(keyword)
+          );
           const newToggleStatus = newKeywords.map((keyword) => ({
             keyword,
             isOn: true,
           }));
-          return [...prev, ...newToggleStatus];
+
+          const notDeletedPrevToggleStatus = prev.filter(({ keyword }) =>
+            currentKeywords.includes(keyword)
+          );
+          return [...notDeletedPrevToggleStatus, ...newToggleStatus];
         });
       }
     }


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/901b4ef3-bdb0-4b8a-b45c-c96e0a4ac850

### 작업 내용
- 하이라이트 시키는 토글 버튼들의 상태를 동기화했습니다.
- 키워드 버튼 컴포넌트를 [전체 키워드 토글 버튼("Highlight All Keywords")]과 [개별 키워드 토글 버튼]으로 분리했습니다.
- 공통 부모에 모든 키워드 토글 상태를 나타내는 toggleStatus 상태를 생성했습니다. 기존에는 개별 키워드 버튼이 각각의 isOn을 지역상태로 가지고 있었습니다.
~~~
// toggleStatus 상태
[
  {keyword: '그리핀도르', isOn: true},
  {keyword: '슬리데린', isOn: true},
  {keyword: '래번클로', isOn: true}
]

~~~

### 기존 계획과 달라진 부분(+이유와 함께)
- 기존 요구사항에서는 전체 키워드 토글 버튼과 개별 키워드 버튼의 동기화가 없었습니다. 
- 시연 후 추가 요구사항이 만들어져 현재 작업을 진행했습니다.

### 구현한 내용(체크박스로 나타내기)
- [X] 전체 키워드 토글 버튼이 On이 될 경우 개별 키워드 버튼들이 모두 On이 됩니다.
- [X] 전체 키워드 토글 버튼이 Off가 될 경우 개별 키워드 버튼들이 모두 Off가 됩니다.
- [X] 개별 키워드 버튼들이 모두 On이 될 경우 전체 키워드 토글 버튼도 On이 됩니다.
- [X] 개별 키워드 버튼들이 모두 Off 될 경우 전체 키워드 토글 버튼도 Off가 됩니다.
- [X] 새로운 키워드가 추가될 시, 기존 키워드들의 토글 상태가 변경되지 않도록 작업했습니다.

### 리뷰어가 집중적으로 바줬으면 하는 것
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #52 
