### PR TITLE
feat: history item 저장 및 노출

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ function App() {
     if (request.message === "Get user authentication") {
       localStorage.setItem("userEmail", request.emailData);
       localStorage.setItem("userAccessToken", request.tokenData);
+      window.dispatchEvent(new Event("storage"));
     }
     return true;
   });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ const queryClient = new QueryClient();
 
 function App() {
   const [countsPerKeywords, setCountsPerKeywords] = useState([]);
+  const [historyItem, setHistoryItem] = useState([]);
 
   chrome.runtime.onMessage.addListener((request) => {
     if (request.message === "Get user authentication") {
@@ -23,12 +24,18 @@ function App() {
   return (
     <UserInfoProvider>
       <QueryClientProvider client={queryClient}>
-        <HistorySection countsPerKeywords={countsPerKeywords} />
+        <HistorySection
+          countsPerKeywords={countsPerKeywords}
+          setHistoryItem={setHistoryItem}
+        />
         <SearchSection
           countsPerKeywords={countsPerKeywords}
           setCountsPerKeywords={setCountsPerKeywords}
         />
-        <LatelyHistoryGroup />
+        <LatelyHistoryGroup
+          historyItem={historyItem}
+          setHistoryItem={setHistoryItem}
+        />
       </QueryClientProvider>
     </UserInfoProvider>
   );

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -1,11 +1,14 @@
 import PropTypes from "prop-types";
 
 import { useUserInfo } from "../../context/UserInfo";
-import { addHistoryToDefaultGroup } from "../../firebase/history";
+import {
+  addHistoryToDefaultGroup,
+  getHistoriesInDefaultGroup,
+} from "../../firebase/history";
 import { addNewUserAndDefaultGroup, getUser } from "../../firebase/user";
 import IconButton from "../shared/IconButton";
 
-export default function HistorySection({ countsPerKeywords }) {
+export default function HistorySection({ countsPerKeywords, setHistoryItem }) {
   const { userInfo } = useUserInfo();
 
   function handleMovePage() {
@@ -26,6 +29,13 @@ export default function HistorySection({ countsPerKeywords }) {
       }
       const history = await getHistoryData(countsPerKeywords);
       await addHistoryToDefaultGroup(userId, history);
+
+      async function getHistoryItem(userEmail) {
+        let userId = await getUser(userEmail);
+        const histories = await getHistoriesInDefaultGroup(userId);
+        setHistoryItem(histories);
+      }
+      getHistoryItem(userInfo[0]);
     }
   }
 
@@ -68,4 +78,5 @@ export default function HistorySection({ countsPerKeywords }) {
 
 HistorySection.propTypes = {
   countsPerKeywords: PropTypes.array.isRequired,
+  setHistoryItem: PropTypes.func.isRequired,
 };

--- a/src/components/history-section/index.jsx
+++ b/src/components/history-section/index.jsx
@@ -6,15 +6,10 @@ import { addNewUserAndDefaultGroup, getUser } from "../../firebase/user";
 import IconButton from "../shared/IconButton";
 
 export default function HistorySection({ countsPerKeywords }) {
-  const { userInfo, setUserInfo } = useUserInfo();
+  const { userInfo } = useUserInfo();
 
   function handleMovePage() {
-    const userEmail = localStorage.getItem("userEmail");
-    const userAccessToken = localStorage.getItem("userAccessToken");
-
-    setUserInfo([userEmail, userAccessToken]);
-
-    if (userEmail && userAccessToken) {
+    if (userInfo[0]) {
       chrome.tabs.create({ url: "http://localhost:5173" });
     } else {
       chrome.tabs.create({ url: "http://localhost:5173/login" });
@@ -22,22 +17,12 @@ export default function HistorySection({ countsPerKeywords }) {
   }
 
   async function handleAddHistory(countsPerKeywords) {
-    const userEmail = localStorage.getItem("userEmail");
-    const userAccessToken = localStorage.getItem("userAccessToken");
-
-    setUserInfo([userEmail, userAccessToken]);
-
-    if (!userEmail && !userAccessToken) {
+    if (!userInfo[0]) {
       chrome.tabs.create({ url: "http://localhost:5173/login" });
     } else {
-      const email = userInfo[0];
-
-      if (!email) {
-        return;
-      }
-      let userId = await getUser(email);
+      let userId = await getUser(userInfo[0]);
       if (!userId) {
-        userId = await addNewUserAndDefaultGroup(email);
+        userId = await addNewUserAndDefaultGroup(userInfo[0]);
       }
       const history = await getHistoryData(countsPerKeywords);
       await addHistoryToDefaultGroup(userId, history);

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -1,43 +1,10 @@
-import { useEffect, useState } from "react";
-
-import { getHistories } from "../../firebase/CRUD";
-import HistoryItem from "../shared/HistoryItem";
-
 export default function LatelyHistoryGroup() {
-  const [historyList, setHistoryList] = useState([]);
-
-  useEffect(() => {
-    chrome.runtime.sendMessage(
-      {
-        message: "userStatus",
-      },
-      (response) => {
-        if (response.message) {
-          const userToken = response.message;
-          const groupId = "new-keyword-group";
-          getHistories(userToken, groupId, setHistoryList);
-        }
-      }
-    );
-  }, []);
-
   return (
     <div>
       <p className="text-lg font-semibold mt-[10px] mb-[10px]">
         lately History Group
       </p>
-      <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]">
-        {historyList.map((history, index) => {
-          return (
-            <HistoryItem
-              key={index}
-              url={history.url}
-              favicon={history.faviconSrc}
-              siteTitle={history.siteTitle}
-            />
-          );
-        })}
-      </ul>
+      <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]"></ul>
     </div>
   );
 }

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { useEffect } from "react";
 
 import { useUserInfo } from "../../context/UserInfo";
 import { getHistoriesInDefaultGroup } from "../../firebase/history";
 import { getUser } from "../../firebase/user";
 import HistoryItem from "../shared/HistoryItem";
 
-export default function LatelyHistoryGroup() {
-  const [historyItem, setHistoryItem] = useState([]);
+export default function LatelyHistoryGroup({ historyItem, setHistoryItem }) {
   const { userInfo } = useUserInfo();
 
   useEffect(() => {
@@ -38,3 +38,8 @@ export default function LatelyHistoryGroup() {
     </div>
   );
 }
+
+LatelyHistoryGroup.propTypes = {
+  historyItem: PropTypes.array.isRequired,
+  setHistoryItem: PropTypes.func.isRequired,
+};

--- a/src/components/lately-history-croup/LatelyHistoryGroup.jsx
+++ b/src/components/lately-history-croup/LatelyHistoryGroup.jsx
@@ -1,10 +1,40 @@
+import { useEffect, useState } from "react";
+
+import { useUserInfo } from "../../context/UserInfo";
+import { getHistoriesInDefaultGroup } from "../../firebase/history";
+import { getUser } from "../../firebase/user";
+import HistoryItem from "../shared/HistoryItem";
+
 export default function LatelyHistoryGroup() {
+  const [historyItem, setHistoryItem] = useState([]);
+  const { userInfo } = useUserInfo();
+
+  useEffect(() => {
+    async function getHistoryItem(userEmail) {
+      let userId = await getUser(userEmail);
+      const histories = await getHistoriesInDefaultGroup(userId);
+      setHistoryItem(histories);
+    }
+    userInfo[0] && getHistoryItem(userInfo[0]);
+  }, [userInfo]);
+
   return (
     <div>
       <p className="text-lg font-semibold mt-[10px] mb-[10px]">
         lately History Group
       </p>
-      <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]"></ul>
+      <ul className="bg-[#f6f6f6] h-60 overflow-y-scroll border text-left px-[10px] py-[20px]">
+        {historyItem.map((history, index) => {
+          return (
+            <HistoryItem
+              key={index}
+              favicon={history.faviconSrc}
+              siteTitle={history.siteTitle}
+              url={history.url}
+            />
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/src/components/shared/HistoryItem.jsx
+++ b/src/components/shared/HistoryItem.jsx
@@ -1,26 +1,5 @@
-import PropTypes from "prop-types";
-
-export default function HistoryItem({ url, favicon, siteTitle }) {
-  function handleMoveUrl() {
-    chrome.tabs.create({ url: url });
-  }
+export default function HistoryItem() {
   return (
-    <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
-      <div
-        onClick={handleMoveUrl}
-        className="flex gap-[10px] justify-start items-center"
-      >
-        <div className="w-[20px] h-[20px] object-fill rounded-full">
-          <img src={favicon} />
-        </div>
-        {siteTitle}
-      </div>
-    </li>
+    <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full"></li>
   );
 }
-
-HistoryItem.propTypes = {
-  url: PropTypes.string.isRequired,
-  favicon: PropTypes.string.isRequired,
-  siteTitle: PropTypes.string.isRequired,
-};

--- a/src/components/shared/HistoryItem.jsx
+++ b/src/components/shared/HistoryItem.jsx
@@ -1,5 +1,26 @@
-export default function HistoryItem() {
+import PropTypes from "prop-types";
+
+export default function HistoryItem({ favicon, siteTitle, url }) {
+  function handleMoveUrl() {
+    chrome.tabs.create({ url: url });
+  }
   return (
-    <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full"></li>
+    <li className="text-xs text-[#555] bg-[#fff] border px-[15px] mb-[15px] py-[10px] rounded-full w-full">
+      <div
+        onClick={handleMoveUrl}
+        className="flex gap-[10px] justify-start items-center"
+      >
+        <div className="w-[20px] h-[20px] object-fill rounded-full">
+          <img src={favicon} />
+        </div>
+        {siteTitle}
+      </div>
+    </li>
   );
 }
+
+HistoryItem.propTypes = {
+  url: PropTypes.string.isRequired,
+  favicon: PropTypes.string.isRequired,
+  siteTitle: PropTypes.string.isRequired,
+};

--- a/src/context/UserInfo.jsx
+++ b/src/context/UserInfo.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 
 const UserInfoContext = createContext(null);
 
@@ -11,6 +11,24 @@ export default function UserInfoProvider({ children }) {
 
     return userInfo;
   });
+
+  useEffect(() => {
+    function setUserData() {
+      const userEmail = localStorage.getItem("userEmail");
+      const userAccessToken = localStorage.getItem("userAccessToken");
+
+      if (
+        userEmail !== null &&
+        userAccessToken !== null &&
+        userEmail !== userInfo[0] &&
+        userAccessToken !== userInfo[1]
+      ) {
+        setUserInfo([userEmail, userAccessToken]);
+      }
+    }
+    window.addEventListener("storage", setUserData);
+    return () => window.removeEventListener("storage", setUserData);
+  }, []);
 
   return (
     <UserInfoContext.Provider value={{ userInfo, setUserInfo }}>

--- a/src/firebase/history.js
+++ b/src/firebase/history.js
@@ -1,4 +1,4 @@
-import { addDoc, collection } from "firebase/firestore";
+import { addDoc, collection, getDocs, limit, query } from "firebase/firestore";
 
 import { db } from "./firebase";
 
@@ -23,4 +23,28 @@ export async function addHistoryToDefaultGroup(userId, history) {
   const historyDocRef = await addDoc(historiesRef, historyForDB);
 
   return historyDocRef.id;
+}
+
+export async function getHistoriesInDefaultGroup(userId) {
+  const histories = [];
+  const defaultGroupHistoriesRef = query(
+    collection(db, "users", userId, "groups", "default", "histories"),
+    limit[10]
+  );
+
+  const defaultGroupHistoriesQuerySnapshot = await getDocs(
+    defaultGroupHistoriesRef
+  );
+  defaultGroupHistoriesQuerySnapshot.forEach((historyDoc) => {
+    histories.push({
+      id: historyDoc.id,
+      faviconSrc: historyDoc.data().faviconSrc,
+      siteTitle: historyDoc.data().siteTitle,
+      url: historyDoc.data().url,
+      createdTime: historyDoc.data().createdTime,
+      keywords: historyDoc.data().keywords,
+    });
+  });
+
+  return histories;
 }


### PR DESCRIPTION
### 구현사진

https://github.com/user-attachments/assets/611a3107-a2d8-49f8-b6c2-341a7d2b590e

### 작업 내용
- history section의 history 저장 버튼을 누르면 firebase로 data가 저장된다.
- 로그인을 하면 lately history section에서 최근 저장한 history items가 노출된다.
- 위의 저장 버튼을 클릭하면 바로 lately history section에 즉각 노출된다.
- 로그인한 유저 정보를 담고 있는 useContext 최신화 이슈 수정
### 기존 계획과 달라진 부분(+이유와 함께)
- 로그인한 유저 정보를 전역상태로 관리하기 위하여 useContext를 사용했으나, 초기에 null을 가지고 있는 상태 이후에 새로고침을 해야만 null에서 유저 정보로 상태가 변하는 현상을 보완하고자 함
- localStorage의 data 변화에 따라 이벤트가 발생하는 메소드를 사용하여, 유저 정보가 localStorage에 저장되면 바로 useContext를 업데이트 하도록 수정
### 구현한 내용(체크박스로 나타내기)
- history section

  - [X] 저장 버튼 클릭 시 history item 저장(history item 저장 로직을 활용)
- lately history section

  - [X] 최근 저장한 history item 노출(history item 가져오는 로직을 활용)
  - [X] history item은 최대 10개까지 로드
  - [X] 저장 버튼을 누르면 바로 lately history section 내에 노출
- 기타
  - [X] useContext 상태 업데이트 오류 수정
### 관련 이슈
feat: history item 저장 및 노출 #51 