### PR TITLE
fix: 엘로우 마그네슘 에러 대응을 위한 단축키 명령어 수정

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sticky Searcher",
   "description": "사용자의 검색환경을 개선해보자 🔎",
-  "version": "1.1",
+  "version": "1.1.1",
   "manifest_version": 3,
   "action": {
     "default_title": "Click to open panel",
@@ -32,8 +32,9 @@
   "commands": {
     "_execute_action": {
       "suggested_key": {
-        "windows": "Ctrl + F",
-        "mac": "Command + F"
+        "default": "Alt + F",
+        "windows": "Alt + F",
+        "mac": "Alt + F"
       }
     }
   }


### PR DESCRIPTION
### 작업 내용
- 엘로우 마그네슘 에러 대응을 위한 단축키 명령어 수정
- #65 
※ 확장 프로그램 게시 심사 지연으로 인해 일부 변경사항을 뒤늦게 푸시했습니다. 기능상 차이는 없으며, 배포 시점에 사용된 코드와 동일합니다.
